### PR TITLE
Add light mode as the default theme

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -7,6 +7,7 @@ import { Providers } from "@/components/Providers";
 import { messages } from "@/lib/i18n/messages";
 import { URL_LOCALES, htmlLang, isUrlLocale, ogLocale, urlToLocale } from "@/lib/i18n/paths";
 import { site } from "@/lib/site";
+import { themeBootScript } from "@/lib/theme-script";
 import "../globals.css";
 
 const geistSans = Geist({
@@ -69,11 +70,12 @@ export default async function LocaleLayout({
   return (
     <html
       lang={htmlLang[locale]}
+      data-theme="light"
       suppressHydrationWarning
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
-      style={{ colorScheme: "dark" }}
     >
       <body className="flex min-h-full flex-col bg-canvas font-sans text-ink antialiased">
+        <script dangerouslySetInnerHTML={{ __html: themeBootScript }} />
         <Providers>
           <Header />
           <main className="flex-1">{children}</main>

--- a/app/global-not-found.tsx
+++ b/app/global-not-found.tsx
@@ -22,6 +22,7 @@ export default function GlobalNotFound() {
   return (
     <html
       lang="en"
+      data-theme="light"
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
       <body className="flex min-h-full flex-col bg-canvas font-sans text-ink antialiased">

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,6 +1,32 @@
 @import "tailwindcss";
 
-:root {
+:root,
+html[data-theme="light"] {
+  color-scheme: light;
+  --canvas: #f6f7f9;
+  --elevated: #f1f3f6;
+  --card: #ffffff;
+  --card-hover: #f8f9fb;
+  --input: #ffffff;
+  --line: rgb(15 23 42 / 0.1);
+  --line-strong: rgb(15 23 42 / 0.18);
+  --ink: #111318;
+  --mute: #5c6370;
+  --faint: #7b8290;
+  --accent: #4f7cff;
+  --accent-2: #6d28d9;
+  --accent-soft: rgb(79 124 255 / 0.1);
+  --danger: #dc2626;
+  --warn: #d97706;
+  --ok: #16a34a;
+  --inverse: #ffffff;
+  --shadow-search: 0 1px 2px rgb(15 23 42 / 0.06);
+  --shadow-menu: 0 16px 40px rgb(15 23 42 / 0.1);
+  --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+html[data-theme="dark"] {
   color-scheme: dark;
   --canvas: #0b0d10;
   --elevated: #171a20;
@@ -19,8 +45,8 @@
   --warn: #ff9f0a;
   --ok: #34c759;
   --inverse: #0b0d10;
-  --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
-  --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+  --shadow-search: 0 1px 2px rgb(0 0 0 / 0.4);
+  --shadow-menu: 0 16px 40px rgb(0 0 0 / 0.45);
 }
 
 @theme inline {
@@ -78,7 +104,25 @@ body {
 .featured-glow {
   box-shadow:
     0 0 80px rgb(79 124 255 / 0.08),
+    0 8px 24px rgb(15 23 42 / 0.05);
+}
+
+html[data-theme="dark"] .featured-glow {
+  box-shadow:
+    0 0 80px rgb(79 124 255 / 0.08),
     0 0 120px rgb(139 92 246 / 0.05);
+}
+
+.search-field-hero {
+  box-shadow: var(--shadow-search);
+}
+
+.search-field-hero:focus {
+  box-shadow: 0 12px 40px rgb(79 124 255 / 0.12);
+}
+
+.search-menu {
+  box-shadow: var(--shadow-menu);
 }
 
 .prompt-scroll::-webkit-scrollbar {
@@ -87,7 +131,7 @@ body {
 }
 
 .prompt-scroll::-webkit-scrollbar-thumb {
-  background: rgb(255 255 255 / 0.16);
+  background: var(--line-strong);
   border-radius: 999px;
 }
 

--- a/components/CopyButton.tsx
+++ b/components/CopyButton.tsx
@@ -40,7 +40,7 @@ export function CopyButton({ text, label, className, variant = "ghost" }: CopyBu
         "spring-press inline-flex h-9 items-center justify-center gap-1.5 rounded-[10px] px-3 text-[13px] font-medium transition",
         variant === "ghost" &&
           "border border-line bg-transparent text-mute hover:border-line-strong hover:text-ink",
-        variant === "solid" && "h-11 bg-ink px-5 text-sm text-inverse hover:bg-neutral-800",
+        variant === "solid" && "h-11 bg-ink px-5 text-sm text-inverse hover:opacity-90",
         variant === "inline" && "h-8 px-2.5 text-mute hover:text-ink",
         className,
       )}

--- a/components/CustomizePrompt.tsx
+++ b/components/CustomizePrompt.tsx
@@ -53,7 +53,7 @@ export function CustomizePrompt({ useCase }: { useCase: UseCase }) {
       <button
         type="button"
         onClick={generate}
-        className="spring-press mt-5 inline-flex h-11 items-center rounded-[10px] bg-ink px-4 text-sm text-inverse hover:bg-neutral-800"
+        className="spring-press mt-5 inline-flex h-11 items-center rounded-[10px] bg-ink px-4 text-sm text-inverse hover:opacity-90"
       >
         {t("detail.generate")}
       </button>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -10,6 +10,7 @@ import { BotFace, botColorFor } from "./BotFace";
 import { LanguageSwitch } from "./LanguageSwitch";
 import { LocaleLink } from "./LocaleLink";
 import { SearchBar } from "./SearchBar";
+import { ThemeToggle } from "./ThemeToggle";
 import { useSaved } from "./saved";
 
 export function Header() {
@@ -65,6 +66,7 @@ export function Header() {
 
         <div className="flex items-center gap-1">
           <HeaderSearch />
+          <ThemeToggle />
           <div className="hidden lg:block">
             <LanguageSwitch />
           </div>

--- a/components/Providers.tsx
+++ b/components/Providers.tsx
@@ -1,16 +1,19 @@
 "use client";
 
 import { LocaleProvider } from "@/lib/i18n";
+import { ThemeProvider } from "@/lib/theme";
 import { CursorBot } from "./CursorBot";
 import { SavedProvider } from "./saved";
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
-    <LocaleProvider>
-      <SavedProvider>
-        {children}
-        <CursorBot />
-      </SavedProvider>
-    </LocaleProvider>
+    <ThemeProvider>
+      <LocaleProvider>
+        <SavedProvider>
+          {children}
+          <CursorBot />
+        </SavedProvider>
+      </LocaleProvider>
+    </ThemeProvider>
   );
 }

--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -203,7 +203,7 @@ export function SearchBar({
         className={cn(
           "w-full border border-line bg-elevated pr-16 pl-12 text-[15px] text-ink placeholder:text-faint transition-[border-color,box-shadow] duration-200",
           variant === "hero"
-            ? "h-14 rounded-full shadow-[0_1px_2px_rgb(0_0_0/0.4)] focus:border-line-strong focus:shadow-[0_12px_40px_rgb(79_124_255/0.12)]"
+            ? "search-field-hero h-14 rounded-full focus:border-line-strong"
             : "h-12 rounded-full focus:border-line-strong",
         )}
       />
@@ -212,7 +212,7 @@ export function SearchBar({
       </span>
 
       {showResults || showSuggestions ? (
-        <div className="absolute inset-x-0 top-[calc(100%+8px)] z-30 overflow-hidden rounded-2xl border border-line bg-card shadow-[0_16px_40px_rgb(0_0_0/0.45)]">
+        <div className="search-menu absolute inset-x-0 top-[calc(100%+8px)] z-30 overflow-hidden rounded-2xl border border-line bg-card">
           {showSuggestions ? (
             <p className="px-4 pt-3 pb-1 text-[12px] text-faint">{t("search.try")}</p>
           ) : null}

--- a/components/StatusBadge.tsx
+++ b/components/StatusBadge.tsx
@@ -2,7 +2,7 @@ import { cn } from "@/lib/cn";
 import type { TrustStatus } from "@/data/verification";
 
 const styles: Record<TrustStatus, string> = {
-  official: "border-accent-2/35 bg-accent-2/10 text-[#c4b5fd]",
+  official: "border-accent-2/35 bg-accent-2/10 text-accent-2",
   library: "border-line bg-elevated text-faint",
   community: "border-line bg-elevated text-mute",
   tested: "border-ok/30 bg-ok/10 text-ok",

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { Moon, Sun } from "lucide-react";
+import { useI18n } from "@/lib/i18n";
+import { useTheme } from "@/lib/theme";
+
+export function ThemeToggle() {
+  const { t } = useI18n();
+  const { toggleTheme } = useTheme();
+
+  return (
+    <button
+      type="button"
+      onClick={toggleTheme}
+      aria-label={t("theme.toggle")}
+      className="inline-flex size-9 items-center justify-center rounded-lg text-mute hover:text-ink"
+    >
+      <Sun className="hidden size-3.5 [[data-theme=dark]_&]:block" strokeWidth={1.75} />
+      <Moon className="size-3.5 [[data-theme=dark]_&]:hidden" strokeWidth={1.75} />
+    </button>
+  );
+}

--- a/lib/i18n/messages.ts
+++ b/lib/i18n/messages.ts
@@ -3,6 +3,11 @@ import type { Locale } from "./types";
 export const messages = {
   en: {
     lang: { label: "Language" },
+    theme: {
+      toggle: "Toggle light and dark mode",
+      toDark: "Switch to dark mode",
+      toLight: "Switch to light mode",
+    },
     nav: {
       discover: "Discover",
       useCases: "Use Cases",
@@ -310,6 +315,11 @@ export const messages = {
   },
   "zh-Hant": {
     lang: { label: "語言" },
+    theme: {
+      toggle: "切換日頭同黑夜模式",
+      toDark: "轉做黑夜模式",
+      toLight: "轉做日頭模式",
+    },
     nav: {
       discover: "發現",
       useCases: "使用案例",
@@ -614,6 +624,11 @@ export const messages = {
   },
   "zh-Hans": {
     lang: { label: "语言" },
+    theme: {
+      toggle: "切换日间和夜间模式",
+      toDark: "切换到夜间模式",
+      toLight: "切换到日间模式",
+    },
     nav: {
       discover: "发现",
       useCases: "使用场景",

--- a/lib/theme-script.ts
+++ b/lib/theme-script.ts
@@ -1,0 +1,3 @@
+export const THEME_STORAGE_KEY = "usegrokbot:theme";
+
+export const themeBootScript = `(function(){try{var t=localStorage.getItem("${THEME_STORAGE_KEY}");document.documentElement.setAttribute("data-theme",t==="dark"?"dark":"light");document.documentElement.style.colorScheme=t==="dark"?"dark":"light";}catch(e){document.documentElement.setAttribute("data-theme","light");document.documentElement.style.colorScheme="light";}})();`;

--- a/lib/theme.tsx
+++ b/lib/theme.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { createContext, useCallback, useContext, useMemo } from "react";
+import { THEME_STORAGE_KEY } from "@/lib/theme-script";
+
+export type Theme = "light" | "dark";
+
+type ThemeValue = {
+  setTheme: (theme: Theme) => void;
+  toggleTheme: () => void;
+};
+
+const ThemeContext = createContext<ThemeValue | null>(null);
+
+export function applyTheme(theme: Theme) {
+  document.documentElement.setAttribute("data-theme", theme);
+  document.documentElement.style.colorScheme = theme;
+}
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const setTheme = useCallback((next: Theme) => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, next);
+    applyTheme(next);
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    const current = document.documentElement.getAttribute("data-theme") === "dark" ? "dark" : "light";
+    setTheme(current === "dark" ? "light" : "dark");
+  }, [setTheme]);
+
+  const value = useMemo(() => ({ setTheme, toggleTheme }), [setTheme, toggleTheme]);
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme() {
+  const value = useContext(ThemeContext);
+  if (!value) throw new Error("useTheme must be used inside ThemeProvider");
+  return value;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add a day/light theme and make it the default. Dark mode stays available from the header toggle.

**What changed**
- Light tokens are the default on `:root` / `html[data-theme="light"]`
- Previous dark tokens live under `html[data-theme="dark"]`
- Header toggle (moon in light, sun in dark) persists the choice in `localStorage`
- An inline boot script applies the stored theme before paint so first load stays light unless the visitor already chose dark
- Does not follow `prefers-color-scheme`

**Default**
First visit is light. Only `localStorage === "dark"` switches to night.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-babec7c6-f48c-40f4-9b80-594f1a6bd493?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-babec7c6-f48c-40f4-9b80-594f1a6bd493&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

