### PR TITLE
Add a GitHub star button to the header and footer

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -4,6 +4,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import { Footer } from "@/components/Footer";
 import { Header } from "@/components/Header";
 import { Providers } from "@/components/Providers";
+import { getGithubStars } from "@/lib/github";
 import { messages } from "@/lib/i18n/messages";
 import { URL_LOCALES, htmlLang, isUrlLocale, ogLocale, urlToLocale } from "@/lib/i18n/paths";
 import { site } from "@/lib/site";
@@ -75,6 +76,7 @@ export default async function LocaleLayout({
 }) {
   const { locale } = await params;
   if (!isUrlLocale(locale)) notFound();
+  const stars = await getGithubStars();
 
   return (
     <html
@@ -86,9 +88,9 @@ export default async function LocaleLayout({
       <body className="flex min-h-full flex-col bg-canvas font-sans text-ink antialiased">
         <script dangerouslySetInnerHTML={{ __html: themeBootScript }} />
         <Providers>
-          <Header />
+          <Header stars={stars} />
           <main className="flex-1">{children}</main>
-          <Footer />
+          <Footer stars={stars} />
         </Providers>
       </body>
     </html>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -2,15 +2,16 @@
 
 import { useI18n } from "@/lib/i18n";
 import { BotFace, botColorFor } from "./BotFace";
+import { GitHubStar } from "./GitHubStar";
 import { LocaleLink } from "./LocaleLink";
 
-export function Footer() {
+export function Footer({ stars }: { stars?: number | null }) {
   const { t } = useI18n();
 
   return (
     <footer className="mt-auto border-t border-line">
       <div className="mx-auto flex max-w-[1240px] flex-col px-5 py-12 md:px-8">
-        <div className="flex flex-wrap items-center gap-x-6 gap-y-2 text-sm text-mute">
+        <div className="flex flex-wrap items-center gap-x-6 gap-y-3 text-sm text-mute">
           <LocaleLink href="/" className="flex items-center gap-2 text-ink">
             <BotFace size={18} color={botColorFor("usegrokbot")} />
             UseGrokBot
@@ -36,6 +37,7 @@ export function Footer() {
           <LocaleLink href="/submit" className="hover:text-ink">
             {t("nav.submitShort")}
           </LocaleLink>
+          <GitHubStar stars={stars} label="always" />
         </div>
         <p className="mt-6 text-[12px] text-faint">
           <a href="https://github.com/jeremy-prt/bloub" className="hover:text-mute" rel="noreferrer">

--- a/components/GitHubStar.tsx
+++ b/components/GitHubStar.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { Star } from "lucide-react";
+import { cn } from "@/lib/cn";
+import { formatStarCount } from "@/lib/format";
+import { useI18n } from "@/lib/i18n";
+import { site } from "@/lib/site";
+
+export function GitHubStar({
+  stars,
+  className,
+  label = "responsive",
+}: {
+  stars?: number | null;
+  className?: string;
+  label?: "responsive" | "always";
+}) {
+  const { t } = useI18n();
+  const count = typeof stars === "number" ? formatStarCount(stars) : null;
+
+  return (
+    <a
+      href={site.githubUrl}
+      target="_blank"
+      rel="noreferrer"
+      aria-label={t("github.starAria")}
+      className={cn(
+        "inline-flex h-8 items-center overflow-hidden rounded-lg border border-line text-[12px] text-mute transition hover:border-line-strong hover:text-ink",
+        className,
+      )}
+    >
+      <span className="inline-flex items-center gap-1.5 px-2.5">
+        <Star className="size-3.5" strokeWidth={1.75} />
+        <span className={label === "always" ? undefined : "hidden sm:inline"}>{t("github.star")}</span>
+      </span>
+      {count ? (
+        <span className="border-l border-line px-2 font-mono text-[11px] text-faint tabular-nums">
+          {count}
+        </span>
+      ) : null}
+    </a>
+  );
+}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -7,13 +7,14 @@ import { cn } from "@/lib/cn";
 import { useI18n } from "@/lib/i18n";
 import { stripLocalePrefix } from "@/lib/i18n/paths";
 import { BotFace, botColorFor } from "./BotFace";
+import { GitHubStar } from "./GitHubStar";
 import { LanguageSwitch } from "./LanguageSwitch";
 import { LocaleLink } from "./LocaleLink";
 import { SearchBar } from "./SearchBar";
 import { ThemeToggle } from "./ThemeToggle";
 import { useSaved } from "./saved";
 
-export function Header() {
+export function Header({ stars }: { stars?: number | null }) {
   const pathname = usePathname();
   const path = stripLocalePrefix(pathname);
   const { slugs } = useSaved();
@@ -66,6 +67,7 @@ export function Header() {
 
         <div className="flex items-center gap-1">
           <HeaderSearch />
+          <GitHubStar stars={stars} />
           <ThemeToggle />
           <div className="hidden lg:block">
             <LanguageSwitch />

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -4,6 +4,13 @@ export function setupMinutes(setupTime: string) {
   return setupTime.replace(" min", "");
 }
 
+export function formatStarCount(count: number) {
+  if (count < 1000) return String(count);
+  if (count < 10_000) return `${(count / 1000).toFixed(1).replace(/\.0$/, "")}k`;
+  if (count < 1_000_000) return `${Math.round(count / 1000)}k`;
+  return `${(count / 1_000_000).toFixed(1).replace(/\.0$/, "")}m`;
+}
+
 export function formatRelativeTime(isoDate: string, locale: Locale, now = new Date()) {
   const date = new Date(isoDate.includes("T") ? isoDate : `${isoDate}T12:00:00Z`);
   const diffMs = date.getTime() - now.getTime();

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -1,0 +1,27 @@
+import { site } from "@/lib/site";
+
+const GITHUB_API = `https://api.github.com/repos/${site.githubRepo}`;
+const REVALIDATE_SECONDS = 3600;
+
+export async function getGithubStars(): Promise<number | null> {
+  try {
+    const headers = new Headers({
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      "User-Agent": "usegrokbot.com",
+    });
+    const token = process.env.GITHUB_TOKEN;
+    if (token) headers.set("Authorization", `Bearer ${token}`);
+
+    const response = await fetch(GITHUB_API, {
+      headers,
+      next: { revalidate: REVALIDATE_SECONDS, tags: ["github-stars"] },
+    });
+    if (!response.ok) return null;
+
+    const data = (await response.json()) as { stargazers_count?: unknown };
+    return typeof data.stargazers_count === "number" ? data.stargazers_count : null;
+  } catch {
+    return null;
+  }
+}

--- a/lib/i18n/messages.ts
+++ b/lib/i18n/messages.ts
@@ -13,6 +13,10 @@ export const messages = {
       nextColor: "Change bot color",
       credit: "Bot avatar from bloub",
     },
+    github: {
+      star: "Star",
+      starAria: "Star UseGrokBot on GitHub",
+    },
     nav: {
       discover: "Discover",
       useCases: "Use Cases",
@@ -330,6 +334,10 @@ export const messages = {
       nextColor: "轉機械人顏色",
       credit: "機械人頭像來自 bloub",
     },
+    github: {
+      star: "星星",
+      starAria: "喺 GitHub 畀 UseGrokBot 星星",
+    },
     nav: {
       discover: "發現",
       useCases: "使用案例",
@@ -643,6 +651,10 @@ export const messages = {
       aria: "Grok Bot 头像",
       nextColor: "换机器人颜色",
       credit: "机器人头像来自 bloub",
+    },
+    github: {
+      star: "点星",
+      starAria: "在 GitHub 给 UseGrokBot 点星",
     },
     nav: {
       discover: "发现",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Visitors can star the public repo from the official site, the same way other product sites do.

- Compact **Star** button in the header (label + live count on larger screens; star + count on small screens)
- Same button in the footer
- Count comes from the public GitHub repo API and refreshes about once an hour
- If GitHub is unreachable, the button still links to the repo without a count
- Copy: Star / 星星 / 点星

Repo: https://github.com/a70win-wq/usegrokbot
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-babec7c6-f48c-40f4-9b80-594f1a6bd493?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-babec7c6-f48c-40f4-9b80-594f1a6bd493&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

