### PR TITLE
docs: make UseGrokBot open-source ready

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,63 +1,119 @@
 # Contributing to UseGrokBot
 
-Thanks for helping people see how Grok Bot is actually used.
+Thanks for helping people discover how Grok Bot is actually being used.
 
-## Ways to help
+UseGrokBot is built around one rule:
 
-1. [Submit a use case](https://usegrokbot.com/submit) — paste a public X post.
-2. Open a pull request that adds or fixes a discover story, workflow, integration, or translation.
-3. Fix copy, bugs, or mobile UX.
+> **Curate, explain, attribute, and link back.**
+
+## Ways to contribute
+
+You can help by:
+
+1. Adding a real public Grok Bot example.
+2. Adding or improving an integration.
+3. Improving workflow guides.
+4. Fixing Traditional Chinese / Simplified Chinese translations.
+5. Improving mobile UX, accessibility, or performance.
+6. Fixing bugs or documentation.
 
 ## Submit a use case
 
-The form only asks for:
+The easiest path is the website submission page:
 
-- X post URL (required)
-- Prompt (optional)
-- Notes (optional)
+- English: `https://usegrokbot.com/en/submit`
+- Traditional Chinese: `https://usegrokbot.com/zh-hk/submit`
+- Simplified Chinese: `https://usegrokbot.com/zh-cn/submit`
 
-Everything else should come from the source: author, @handle, date, title, what they built, apps, category, and result or output.
+A submission should start from a **real public source** such as an X post, article, video, or public GitHub project.
 
-## Adding a discover story
+## Source and attribution rules
 
-Stories live in `data/discover.ts`.
+Every community example should preserve the original source.
 
-Required:
+Required where available:
 
-- Real public source URL
-- Author name
-- @handle when the source has one
+- Original source URL
+- Author / publisher name
+- @handle for X sources
 - Published date
-- Result **or** Output
+- Category
 - Integrations
-- Trust status: Official, Tested, or Community
+- Result or Output
+- Trust status
 
-Rules:
+Do not:
 
-- Do not invent X authors, handles, or tweet IDs.
-- Only set `xPostUrl` when you have a real public permalink.
-- Only write a Result number if the original post has that number.
-- If there is no number, use Output.
-- Do not mark a story Tested unless UseGrokBot actually ran the Bot.
-- UseGrokBot is the curator. The original author stays the source.
+- invent authors, handles, dates, or source URLs
+- copy an entire X post or article into UseGrokBot
+- invent performance or revenue numbers
+- mark something as Tested unless UseGrokBot actually tested it
+- remove attribution to the original creator
+
+If the original source gives a measurable number, it may be shown as a **Result**.
+
+If it does not, describe the concrete deliverable as an **Output** instead.
+
+## Discover stories
+
+Discover content currently lives in `data/discover.ts`.
+
+A good discover story explains:
+
+- What they built
+- How it works
+- Why it matters
+- Who should try it
+- Which integrations are involved
+- What Result / Output was produced
+- Where the original source lives
+
+UseGrokBot is the curator / explainer. The original author remains the source.
 
 ## Workflows
 
-Ready-to-build guides live in `data/use-cases/`.
+Ready-to-build guides live under `data/use-cases/`.
 
-If a workflow is inspired by a public example, link it with `relatedUseCase` on the discover story and keep an Inspired by line on the workflow page.
+If a workflow is inspired by a public example:
+
+- link the discover story to the workflow
+- preserve the original source on the discover page
+- keep an `Inspired by` / source relationship where appropriate
+
+## Public resource lists
+
+Public indexes such as `awesome-grok-bot` may be used to **discover candidate sources**.
+
+Do not treat an index as permission to republish every linked work. Follow the original underlying source, write a fresh summary, and keep attribution / link-back.
 
 ## Translations
 
-English is the source copy. Then:
+English is the source copy.
 
-- `zh-Hant` for `zh-hk`
-- `zh-Hans` for `zh-cn`
+- `zh-Hant` → `zh-hk`
+- `zh-Hans` → `zh-cn`
 
-Keep the same keys in `lib/i18n/messages.ts`.
+Keep translation keys aligned with `lib/i18n/messages.ts`.
 
 ## Pull requests
 
-- One change per PR when you can
-- Do not commit `.env`, API keys, or secrets
-- Do not add affiliate claims or fake testimonials
+- Keep each PR focused when possible.
+- Run `npm run lint` and `npm run build` before submitting code changes.
+- Do not commit `.env`, API keys, tokens, passwords, or secrets.
+- Do not add fake testimonials, fake engagement, or unsupported sponsor claims.
+- Explain the source for any factual community case you add.
+
+## Good first contributions
+
+Easy ways to start:
+
+- add integration metadata for one popular app
+- improve one mobile layout issue
+- fix one translation
+- add one verified public Grok Bot source
+- improve one workflow explanation
+- improve docs or accessibility
+
+## License
+
+By contributing code to this repository, you agree that your contribution is licensed under the project's [MIT License](LICENSE).

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 UseGrokBot
+Copyright (c) 2026 UseGrokBot contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,6 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
-The UseGrokBot name, logo, and branding are not granted for reuse by this
-license.

--- a/README.md
+++ b/README.md
@@ -1,56 +1,159 @@
 # UseGrokBot
 
-Discover real Grok Bot workflows from X — then build them yourself.
+<p align="center">
+  <strong>Discover real Grok Bot workflows from X — then build them yourself.</strong>
+</p>
 
-[Live site](https://usegrokbot.com) · [Star this repo](https://github.com/a70win-wq/usegrokbot) · [Submit a use case](https://usegrokbot.com/submit) · [Browse integrations](https://usegrokbot.com/integrations) · [Build a workflow](https://usegrokbot.com/use-cases)
+<p align="center">
+  <a href="https://usegrokbot.com/en">Live site</a> ·
+  <a href="https://usegrokbot.com/en/discover">Discover</a> ·
+  <a href="https://usegrokbot.com/en/use-cases">Workflows</a> ·
+  <a href="https://usegrokbot.com/en/integrations">Integrations</a> ·
+  <a href="https://usegrokbot.com/en/submit">Submit a use case</a>
+</p>
+
+<p align="center">
+  <a href="https://github.com/a70win-wq/usegrokbot/stargazers"><img src="https://img.shields.io/github/stars/a70win-wq/usegrokbot?style=flat-square" alt="GitHub stars" /></a>
+  <a href="https://github.com/a70win-wq/usegrokbot/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-green?style=flat-square" alt="MIT License" /></a>
+  <img src="https://img.shields.io/badge/Grok%20Bot-community%20resource-blueviolet?style=flat-square" alt="Grok Bot community resource" />
+</p>
 
 ![UseGrokBot](https://usegrokbot.com/og.png)
 
-## Why UseGrokBot?
+## What is UseGrokBot?
 
-- Real Grok Bot examples found on X
-- Original author and source on every community case
-- Buildable workflows with prompts and setup
-- Integrations you already use
-- Community submissions
-- Open source
+UseGrokBot is an open-source discovery hub for real Grok Bot use cases.
 
-## How it works
+Instead of dumping prompts into a directory, UseGrokBot starts with real examples shared publicly by the Grok Bot community, keeps attribution to the original source, explains what was built in plain language, and connects useful examples to ready-to-build workflows.
 
 ```text
 Discover → Understand → Build → Copy → Share
 ```
 
-UseGrokBot is not a prompt dump and not another bot directory.
+## Why UseGrokBot?
 
-It is the Grok Bot discovery hub: see what people actually built, understand the workflow, then do it yourself.
+- **Real examples** — discover public Grok Bot use cases from X and the wider community.
+- **Original attribution** — community cases link back to the original author and source.
+- **Plain-English explanations** — understand what the Bot actually did and why it matters.
+- **Buildable workflows** — turn an interesting example into a reusable workflow and prompt.
+- **Integrations** — browse workflows by the apps and tools you already use.
+- **Multilingual** — English, Traditional Chinese, and Simplified Chinese.
+- **Open source** — contribute examples, integrations, translations, docs, and product improvements.
 
-## Stack
+## Trust labels
 
-- Next.js App Router
+UseGrokBot distinguishes between different levels of verification:
+
+- ✅ **Official** — demonstrated or published by xAI / official sources.
+- 🧪 **Tested** — tested by UseGrokBot.
+- 👥 **Community** — shared publicly by the community and linked back to the original source.
+
+We do not invent result numbers. If the original source does not provide a measurable result, the case should be described as an **Output** instead.
+
+## Community-powered discovery
+
+Useful Grok Bot examples are spread across X, tutorials, videos, GitHub repositories, and community writeups. UseGrokBot turns those scattered signals into a structured discovery layer.
+
+A public source can become:
+
+```text
+Source
+  ↓
+Attribution
+  ↓
+Category + Integrations
+  ↓
+Plain-language summary
+  ↓
+Result / Output
+  ↓
+Related build guide
+```
+
+Useful public indexes such as [`awesome-grok-bot`](https://github.com/RongleCat/awesome-grok-bot) can act as discovery sources, while UseGrokBot still links to and attributes the original underlying source.
+
+## Project structure
+
+```text
+app/          Next.js routes and pages
+components/   UI components
+data/         Discover stories, workflows, and structured content
+lib/          i18n and shared utilities
+public/       Static assets
+```
+
+## Tech stack
+
+- Next.js 16 App Router
+- React 19
 - TypeScript
-- Tailwind CSS
-- Local structured content — no auth, no database
+- Tailwind CSS 4
+- Vercel deployment
+- Structured local content
 
-## Develop
+## Local development
 
 ```bash
 npm install
 npm run dev
 ```
 
-## Contribute
+Then open `http://localhost:3000`.
 
-See [CONTRIBUTING.md](CONTRIBUTING.md).
+Useful commands:
 
-The fastest way to add a public example is [Submit a use case](https://usegrokbot.com/submit). Paste the X post. We extract the rest from the source.
+```bash
+npm run lint
+npm run build
+```
 
-Do not invent result numbers. If the original post has no number, publish it as Output.
+## Contributing
+
+Contributions are welcome.
+
+You can help by:
+
+- adding a real Grok Bot example
+- adding or improving an integration
+- improving Traditional / Simplified Chinese translations
+- fixing mobile UX or accessibility issues
+- improving workflow guides
+- fixing bugs or documentation
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the contribution rules.
+
+## Roadmap
+
+The project is moving toward a community-powered, zero-touch ingestion pipeline:
+
+```text
+X / public source
+      ↓
+AI relevance + metadata extraction
+      ↓
+Source / duplicate / evidence validation
+      ↓
+Structured case
+      ↓
+CI validation
+      ↓
+Publish
+```
+
+See [ROADMAP.md](ROADMAP.md) for planned work.
 
 ## License
 
-Code is [MIT](LICENSE). The UseGrokBot name and branding are not granted for reuse.
+The code in this repository is licensed under the [MIT License](LICENSE).
 
-The bot avatar is from [bloub](https://github.com/jeremy-prt/bloub), MIT.
+The MIT license covers the software code. The **UseGrokBot** name, logo, and project branding remain associated with this project and are not a grant of trademark rights.
 
-Independent resource. Not affiliated with xAI.
+Third-party posts, screenshots, articles, videos, logos, names, and other linked materials remain the property of their respective owners and are used only as sources / references where applicable.
+
+## Disclaimer
+
+UseGrokBot is an independent community resource and is not affiliated with, endorsed by, or sponsored by xAI, X, or Cursor.
+
+---
+
+If UseGrokBot helps you discover a useful Grok Bot workflow, consider giving the repo a ⭐ — it helps more people find the project.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,117 @@
+# UseGrokBot Roadmap
+
+UseGrokBot is building an open discovery layer for real Grok Bot use cases.
+
+The long-term goal is simple:
+
+> **Find what people are actually building with Grok Bot, understand it quickly, and build it yourself.**
+
+## Now
+
+- [x] Multilingual site: English, Traditional Chinese, Simplified Chinese
+- [x] Discover feed for real Grok Bot examples
+- [x] Original source attribution
+- [x] Workflow / prompt library
+- [x] Categories and app / integration browsing
+- [x] Submission page
+- [x] Open-source repository
+- [x] MIT license
+- [ ] Improve discover cards with stronger Result / Output presentation
+- [ ] Improve mobile filter density and touch targets
+- [ ] Expand trust labels: Official / Tested / Community
+- [ ] Improve integration filtering and landing pages
+
+## Next: automated ingestion
+
+The main product direction is a **zero-touch ingestion pipeline**.
+
+```text
+X / public source
+      ↓
+Relevance detection
+      ↓
+Metadata extraction
+      ↓
+Attribution + source validation
+      ↓
+Duplicate detection
+      ↓
+Result evidence validation
+      ↓
+Structured discover case
+      ↓
+CI validation
+      ↓
+Publish
+```
+
+Planned work:
+
+- [ ] Monitor public Grok Bot sources for candidate cases
+- [ ] Parse X mentions / submitted public URLs
+- [ ] Extract author, handle, date, integrations, category, and outcome
+- [ ] Detect duplicates automatically
+- [ ] Separate verified numeric `Result` from non-numeric `Output`
+- [ ] Reject unsupported claims automatically
+- [ ] Generate structured content files
+- [ ] Add automated CI content validation
+- [ ] Auto-publish cases that pass validation
+- [ ] Keep failed cases in an error / retry queue instead of blocking the pipeline
+
+## Community
+
+- [ ] Add issue templates
+- [ ] Add pull request template
+- [ ] Add `good first issue` tasks
+- [ ] Add `help wanted` tasks
+- [ ] Make it easier to contribute one integration or one public example
+- [ ] Explore `@UseGrokBot` mention-based submissions on X
+- [ ] Contributor profiles / attribution for repeat contributors
+
+## Discovery
+
+- [ ] Featured Grok Bot Builds
+- [ ] Recently added
+- [ ] Recently verified
+- [ ] Better search across use cases, outcomes, and integrations
+- [ ] Collections such as “Grok Bot for Sales” and “Grok Bot for Founders”
+- [ ] True trending signals when reliable engagement data is available
+
+## Integrations
+
+- [ ] Dedicated integration pages
+- [ ] Popular integrations section
+- [ ] More integration metadata and icons
+- [ ] Cross-filter by category + integration
+- [ ] SEO pages for common combinations such as Grok Bot + Gmail / Slack / GitHub
+
+## Platform
+
+Later-stage ideas:
+
+- [ ] Public JSON feed
+- [ ] Public API for discover stories / workflows / integrations
+- [ ] Machine-readable case schema
+- [ ] External agent access to the UseGrokBot directory
+
+## Sustainability
+
+UseGrokBot should remain useful to normal users without putting core discovery behind a paywall.
+
+Potential sustainability model:
+
+- Sponsored tools
+- Featured integrations
+- Relevant AI / automation sponsors
+
+Sponsored content should always be clearly labeled and should not change editorial trust labels.
+
+## Principles
+
+1. **Original source first** — link back to the creator.
+2. **No fake numbers** — never invent results.
+3. **Explain, don't mirror** — add useful context instead of copying posts.
+4. **Buildable** — connect discovery to workflows whenever possible.
+5. **Automation over manual ops** — normal ingestion should not require human approval.
+6. **Exceptions, not queues** — humans handle failures, not every item.
+7. **Open by default** — let the community improve the project.


### PR DESCRIPTION
## What changed

- Upgrade README for GitHub discovery and stars
- Use standard MIT license text
- Expand contribution guide with source/attribution rules
- Add public roadmap, including zero-touch ingestion direction
- Document `awesome-grok-bot` as a candidate source index while preserving original-source attribution

## Goal

Turn the public repository into a proper open-source project and make it easier for people to understand, star, and contribute to UseGrokBot.