### PR TITLE
feat: auto-ingest awesome-grok-bot Field Cases

### DIFF
--- a/.github/workflows/awesome-grok-bot-auto-ingest.yml
+++ b/.github/workflows/awesome-grok-bot-auto-ingest.yml
@@ -1,0 +1,89 @@
+name: Auto-ingest awesome-grok-bot Field Cases
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 */6 * * *"
+  push:
+    branches: [main]
+    paths:
+      - "scripts/sync-awesome-grok-bot.mjs"
+      - "scripts/ingest-awesome-grok-bot.ts"
+      - ".github/workflows/awesome-grok-bot-auto-ingest.yml"
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: awesome-grok-bot-auto-ingest
+  cancel-in-progress: false
+
+jobs:
+  ingest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Sync Field Cases source feed
+        run: node scripts/sync-awesome-grok-bot.mjs
+
+      - name: Commit fresh source feed before ingest
+        shell: bash
+        run: |
+          git config user.name "usegrokbot-source-bot"
+          git config user.email "usegrokbot-source-bot@users.noreply.github.com"
+
+          if git diff --quiet -- data/source-feeds/awesome-grok-bot-field-cases.json; then
+            echo "Source feed is already current."
+          else
+            git add data/source-feeds/awesome-grok-bot-field-cases.json
+            git commit -m "chore: sync awesome-grok-bot Field Cases"
+            git push origin HEAD:main
+          fi
+
+      - name: Auto-ingest X candidates
+        run: npx tsx scripts/ingest-awesome-grok-bot.ts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AI_GATEWAY_API_KEY: ${{ secrets.AI_GATEWAY_API_KEY }}
+          SOURCE_INGEST_LIMIT: "12"
+          SOURCE_INGEST_MAX_ATTEMPTS: "3"
+
+      - name: Preserve processed feed
+        run: cp data/source-feeds/awesome-grok-bot-field-cases.json /tmp/awesome-grok-bot-field-cases.json
+
+      - name: Refresh main after machine-ingested PRs
+        shell: bash
+        run: |
+          git fetch origin main
+          git reset --hard origin/main
+          mkdir -p data/source-feeds
+          cp /tmp/awesome-grok-bot-field-cases.json data/source-feeds/awesome-grok-bot-field-cases.json
+          node scripts/sync-awesome-grok-bot.mjs
+
+      - name: Commit final source state
+        shell: bash
+        run: |
+          if git diff --quiet -- data/source-feeds/awesome-grok-bot-field-cases.json; then
+            echo "Final source state is already current."
+            exit 0
+          fi
+
+          git add data/source-feeds/awesome-grok-bot-field-cases.json
+          git commit -m "chore: record awesome-grok-bot ingest state"
+          git push origin HEAD:main

--- a/README.md
+++ b/README.md
@@ -72,13 +72,49 @@ Related build guide
 
 Useful public indexes such as [`awesome-grok-bot`](https://github.com/RongleCat/awesome-grok-bot) can act as discovery sources, while UseGrokBot still links to and attributes the original underlying source.
 
+## Automatic source ingestion
+
+UseGrokBot watches the **Field Cases** section of [`RongleCat/awesome-grok-bot`](https://github.com/RongleCat/awesome-grok-bot) every 6 hours.
+
+```text
+awesome-grok-bot / Field Cases
+          ↓
+Source feed + URL dedupe
+          ↓
+X cases → existing machine-ingest pipeline
+          ↓
+AI relevance + metadata extraction
+          ↓
+Source / attribution / result validation
+          ↓
+PR → auto-merge → Discover
+```
+
+Non-X Field Cases (articles, videos, newsletters, notes) remain in the machine-readable source feed until generic-source ingestion supports them.
+
+The synced source index lives at:
+
+```text
+data/source-feeds/awesome-grok-bot-field-cases.json
+```
+
+Local commands:
+
+```bash
+npm run sync:awesome-grok-bot
+npm run ingest:awesome-grok-bot
+```
+
+The source feed is an index of candidates, not permission to republish linked content. UseGrokBot summarizes the original source, preserves attribution, and links back.
+
 ## Project structure
 
 ```text
 app/          Next.js routes and pages
 components/   UI components
-data/         Discover stories, workflows, and structured content
-lib/          i18n and shared utilities
+data/         Discover stories, workflows, source feeds, and structured content
+scripts/      Validation, source sync, and ingestion utilities
+lib/          i18n, ingestion, and shared utilities
 public/       Static assets
 ```
 
@@ -105,6 +141,8 @@ Useful commands:
 ```bash
 npm run lint
 npm run build
+npm run validate:discover
+npm run sync:awesome-grok-bot
 ```
 
 The fastest way to add a public example is [Submit a use case](https://usegrokbot.com/submit). Paste the X post. A machine extracts the rest, validates it, and publishes if it passes.
@@ -126,7 +164,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the contribution rules.
 
 ## Roadmap
 
-X post submissions already run this loop. Other public sources are next:
+X post submissions and the `awesome-grok-bot` X Field Cases source now run through the machine-ingest loop. Generic article / video sources are next:
 
 ```text
 X / public source

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,6 +16,9 @@ The long-term goal is simple:
 - [x] Submission page
 - [x] Open-source repository
 - [x] MIT license
+- [x] X-post machine ingestion: extract, validate, PR, auto-merge
+- [x] Automatic source feed: `awesome-grok-bot` Field Cases every 6 hours
+- [x] Auto-ingest new X Field Cases through the existing machine-ingest pipeline
 - [ ] Improve discover cards with stronger Result / Output presentation
 - [ ] Improve mobile filter density and touch targets
 - [ ] Expand trust labels: Official / Tested / Community
@@ -47,16 +50,20 @@ Publish
 
 Planned work:
 
-- [ ] Monitor public Grok Bot sources for candidate cases
-- [ ] Parse X mentions / submitted public URLs
-- [ ] Extract author, handle, date, integrations, category, and outcome
-- [ ] Detect duplicates automatically
-- [ ] Separate verified numeric `Result` from non-numeric `Output`
-- [ ] Reject unsupported claims automatically
-- [ ] Generate structured content files
-- [ ] Add automated CI content validation
-- [ ] Auto-publish cases that pass validation
-- [ ] Keep failed cases in an error / retry queue instead of blocking the pipeline
+- [x] Monitor a public Grok Bot source for candidate cases (`awesome-grok-bot` Field Cases)
+- [x] Parse submitted public X URLs
+- [x] Extract author, handle, date, integrations, category, and outcome from X
+- [x] Detect duplicate X post IDs automatically
+- [x] Separate verified numeric `Result` from non-numeric `Output` for X ingest
+- [x] Reject unsupported result numbers automatically
+- [x] Generate structured ingested DiscoverStory content
+- [x] Add automated CI content validation
+- [x] Auto-publish X cases that pass validation
+- [x] Keep failed X cases in an error queue instead of blocking normal ingestion
+- [ ] Add more public source indexes / feeds
+- [ ] Add generic article / newsletter / video source ingestion
+- [ ] Parse X mentions such as `@UseGrokBot`
+- [ ] Detect semantic duplicates across different source URLs
 
 ## Community
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "validate:discover": "tsx scripts/validate-discover.ts"
+    "validate:discover": "tsx scripts/validate-discover.ts",
+    "sync:awesome-grok-bot": "node scripts/sync-awesome-grok-bot.mjs",
+    "ingest:awesome-grok-bot": "tsx scripts/ingest-awesome-grok-bot.ts"
   },
   "dependencies": {
     "ai": "^7.0.68",

--- a/scripts/ingest-awesome-grok-bot.ts
+++ b/scripts/ingest-awesome-grok-bot.ts
@@ -1,0 +1,112 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { ingestUseCase } from "../lib/ingest/pipeline";
+
+const FEED_PATH = "data/source-feeds/awesome-grok-bot-field-cases.json";
+const MAX_PER_RUN = Math.max(1, Number(process.env.SOURCE_INGEST_LIMIT ?? "12"));
+const MAX_ATTEMPTS = Math.max(1, Number(process.env.SOURCE_INGEST_MAX_ATTEMPTS ?? "3"));
+const RETRYABLE = new Set(["source_unreadable", "extract_failed", "publish_failed", "publish_not_configured", "unexpected_error"]);
+
+type IngestState = {
+  status: "pending" | "retry" | "published" | "queued" | "skipped" | "source-only";
+  attempts: number;
+  code?: string;
+  reason?: string;
+};
+
+type SourceCase = {
+  id: string;
+  title: string;
+  url: string;
+  sourceSummary: string;
+  sourceType: string;
+  sourceStatus: "candidate" | "already-ingested";
+  ingest: IngestState;
+};
+
+type Feed = {
+  schemaVersion: number;
+  source: Record<string, unknown>;
+  stats: Record<string, number>;
+  cases: SourceCase[];
+};
+
+async function save(feed: Feed) {
+  await writeFile(FEED_PATH, `${JSON.stringify(feed, null, 2)}\n`, "utf8");
+}
+
+function shouldProcess(item: SourceCase) {
+  if (item.sourceType !== "x" || item.sourceStatus !== "candidate") return false;
+  if (!["pending", "retry"].includes(item.ingest.status)) return false;
+  return (item.ingest.attempts ?? 0) < MAX_ATTEMPTS;
+}
+
+function markSkipped(item: SourceCase, code: string, reason: string, attempts: number): IngestState {
+  const retry = RETRYABLE.has(code) && attempts < MAX_ATTEMPTS;
+  return {
+    status: retry ? "retry" : "skipped",
+    attempts,
+    code,
+    reason,
+  };
+}
+
+async function main() {
+  const feed = JSON.parse(await readFile(FEED_PATH, "utf8")) as Feed;
+  const queue = feed.cases.filter(shouldProcess).slice(0, MAX_PER_RUN);
+
+  if (!queue.length) {
+    console.log("No new X Field Cases to ingest.");
+    return;
+  }
+
+  console.log(`Auto-ingesting ${queue.length} X Field Cases from awesome-grok-bot.`);
+
+  for (const candidate of queue) {
+    const item = feed.cases.find((entry) => entry.url === candidate.url)!;
+    const attempts = (item.ingest.attempts ?? 0) + 1;
+    console.log(`\n[${attempts}/${MAX_ATTEMPTS}] ${item.title}\n${item.url}`);
+
+    try {
+      const result = await ingestUseCase({
+        xUrl: item.url,
+        notes: `Discovered via RongleCat/awesome-grok-bot Field Cases. Source-index summary: ${item.sourceSummary}`,
+      });
+
+      if (result.status === "published") {
+        item.ingest = { status: "published", attempts };
+        console.log(`published: ${result.slug}`);
+      } else if (result.status === "queued") {
+        item.ingest = { status: "queued", attempts, reason: result.prUrl };
+        console.log(`queued: ${result.prUrl}`);
+      } else if (result.status === "extracted") {
+        item.ingest = markSkipped(
+          item,
+          "publish_not_configured",
+          "Case extracted successfully but no GitHub publishing token was available.",
+          attempts,
+        );
+        console.log("extracted but not published");
+      } else {
+        item.ingest = markSkipped(item, result.code, result.reason, attempts);
+        console.log(`${item.ingest.status}: ${result.code} — ${result.reason}`);
+      }
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      item.ingest = markSkipped(item, "unexpected_error", reason, attempts);
+      console.error(`unexpected error: ${reason}`);
+    }
+
+    await save(feed);
+  }
+
+  const states = feed.cases.reduce<Record<string, number>>((acc, item) => {
+    acc[item.ingest.status] = (acc[item.ingest.status] ?? 0) + 1;
+    return acc;
+  }, {});
+  console.log("\nSource-feed ingest states:", states);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/sync-awesome-grok-bot.mjs
+++ b/scripts/sync-awesome-grok-bot.mjs
@@ -1,0 +1,157 @@
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { dirname } from "node:path";
+
+const README_URL =
+  process.env.AWESOME_GROK_BOT_README_URL ||
+  "https://raw.githubusercontent.com/RongleCat/awesome-grok-bot/main/README.md";
+const DISCOVER_PATH = "data/discover.ts";
+const INGESTED_PATH = "data/discover/ingested.json";
+const OUTPUT_PATH = "data/source-feeds/awesome-grok-bot-field-cases.json";
+
+function normalizeUrl(value) {
+  try {
+    const url = new URL(value.trim());
+    url.hash = "";
+    url.search = "";
+    const normalized = url.toString().replace(/\/$/, "");
+    return normalized.replace("https://twitter.com/", "https://x.com/");
+  } catch {
+    return value.trim().replace(/\/$/, "");
+  }
+}
+
+function slugify(value) {
+  return value
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 90);
+}
+
+function sourceType(url) {
+  const host = new URL(url).hostname.replace(/^www\./, "");
+  if (host === "x.com" || host === "twitter.com") return "x";
+  if (host === "youtube.com" || host === "youtu.be") return "youtube";
+  if (host.endsWith("substack.com")) return "newsletter";
+  if (host === "note.com") return "note";
+  return "article";
+}
+
+function extractFieldCases(markdown) {
+  const startMarker = "## Field Cases";
+  const start = markdown.indexOf(startMarker);
+  if (start < 0) throw new Error("Could not find ## Field Cases in awesome-grok-bot README");
+
+  const afterStart = markdown.slice(start + startMarker.length);
+  const nextHeading = afterStart.search(/\n##\s+/);
+  const section = nextHeading >= 0 ? afterStart.slice(0, nextHeading) : afterStart;
+
+  const entries = [];
+  const linePattern = /^- \[([^\]]+)\]\((https?:\/\/[^)]+)\)\s+-\s+(.+)$/gm;
+  let match;
+  while ((match = linePattern.exec(section)) !== null) {
+    const [, title, url, summary] = match;
+    entries.push({ title: title.trim(), url: normalizeUrl(url), summary: summary.trim() });
+  }
+
+  if (!entries.length) throw new Error("Field Cases section was found, but no entries could be parsed");
+  return entries;
+}
+
+async function optionalRead(path) {
+  try {
+    return await readFile(path, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function urlsIn(text) {
+  return [...text.matchAll(/https?:\/\/[^\s\"'`)]+/g)].map((match) => normalizeUrl(match[0]));
+}
+
+async function main() {
+  const response = await fetch(README_URL, {
+    headers: { "User-Agent": "UseGrokBot-source-sync" },
+  });
+  if (!response.ok) throw new Error(`Failed to fetch awesome-grok-bot README: ${response.status}`);
+
+  const markdown = await response.text();
+  const fieldCases = extractFieldCases(markdown);
+  const [discoverSource, ingestedSource, previousSource] = await Promise.all([
+    optionalRead(DISCOVER_PATH),
+    optionalRead(INGESTED_PATH),
+    optionalRead(OUTPUT_PATH),
+  ]);
+
+  const existingUrls = new Set([...urlsIn(discoverSource), ...urlsIn(ingestedSource)]);
+
+  let previous = { cases: [] };
+  try {
+    previous = previousSource ? JSON.parse(previousSource) : previous;
+  } catch {
+    previous = { cases: [] };
+  }
+  const previousByUrl = new Map(
+    (Array.isArray(previous.cases) ? previous.cases : []).map((item) => [normalizeUrl(item.url), item]),
+  );
+
+  const cases = fieldCases.map((item) => {
+    const type = sourceType(item.url);
+    const alreadyIngested = existingUrls.has(item.url);
+    const old = previousByUrl.get(item.url);
+    const oldIngest = old?.ingest && typeof old.ingest === "object" ? old.ingest : undefined;
+    const ingest = alreadyIngested
+      ? { status: "published", attempts: oldIngest?.attempts ?? 0 }
+      : oldIngest ?? { status: type === "x" ? "pending" : "source-only", attempts: 0 };
+
+    return {
+      id: slugify(item.title),
+      title: item.title,
+      url: item.url,
+      sourceSummary: item.summary,
+      sourceType: type,
+      sourceIndex: "RongleCat/awesome-grok-bot#field-cases",
+      sourceStatus: alreadyIngested ? "already-ingested" : "candidate",
+      ingest,
+    };
+  });
+
+  const payload = {
+    schemaVersion: 2,
+    source: {
+      name: "awesome-grok-bot Field Cases",
+      repository: "https://github.com/RongleCat/awesome-grok-bot",
+      rawReadme: README_URL,
+      section: "Field Cases",
+      sourceListLicense: "CC0-1.0",
+      note: "The list metadata is CC0. Linked X posts, articles, videos and other source content retain their own rights. UseGrokBot summarizes the original source and links back rather than copying it wholesale.",
+    },
+    stats: {
+      total: cases.length,
+      candidates: cases.filter((item) => item.sourceStatus === "candidate").length,
+      xCandidates: cases.filter((item) => item.sourceStatus === "candidate" && item.sourceType === "x").length,
+      alreadyIngested: cases.filter((item) => item.sourceStatus === "already-ingested").length,
+      sourceOnly: cases.filter((item) => item.ingest.status === "source-only").length,
+    },
+    cases,
+  };
+
+  await mkdir(dirname(OUTPUT_PATH), { recursive: true });
+  const next = `${JSON.stringify(payload, null, 2)}\n`;
+  if (previousSource === next) {
+    console.log(`No source-feed changes. ${payload.stats.total} Field Cases, ${payload.stats.xCandidates} X candidates.`);
+    return;
+  }
+
+  await writeFile(OUTPUT_PATH, next, "utf8");
+  console.log(
+    `Updated ${OUTPUT_PATH}: ${payload.stats.total} total, ${payload.stats.xCandidates} X candidates, ${payload.stats.alreadyIngested} already ingested.`,
+  );
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## What this adds

- Sync `RongleCat/awesome-grok-bot` → `Field Cases` every 6 hours
- Store a machine-readable source feed with candidate / already-ingested status
- Feed new X cases into the existing zero-touch `ingestUseCase` pipeline
- Preserve non-X articles / videos / newsletters as source-only candidates for future generic ingestion
- Retry transient failures up to 3 times; permanent validation failures stop retrying
- Keep original-source attribution and CC0 index metadata separate from linked-source rights
- Document the source feed and update the roadmap

## Flow

`awesome-grok-bot Field Cases → source feed → X candidates → AI extract → validate → PR → auto-merge → Discover`

No human approval is required for normal cases.