### PR TITLE
fix: keep awesome source feed stats and URLs accurate

### DIFF
--- a/.github/workflows/awesome-grok-bot-auto-ingest.yml
+++ b/.github/workflows/awesome-grok-bot-auto-ingest.yml
@@ -46,6 +46,9 @@ jobs:
           SOURCE_INGEST_LIMIT: "10"
           SOURCE_INGEST_MAX_ATTEMPTS: "3"
 
+      - name: Refresh source status after ingest
+        run: node scripts/sync-awesome-grok-bot.mjs
+
       - name: Validate Discover data before publishing
         run: npm run validate:discover
 

--- a/scripts/sync-awesome-grok-bot.mjs
+++ b/scripts/sync-awesome-grok-bot.mjs
@@ -12,9 +12,18 @@ function normalizeUrl(value) {
   try {
     const url = new URL(value.trim());
     url.hash = "";
-    url.search = "";
-    const normalized = url.toString().replace(/\/$/, "");
-    return normalized.replace("https://twitter.com/", "https://x.com/");
+
+    const host = url.hostname.replace(/^www\./, "");
+    if (host === "x.com" || host === "twitter.com") {
+      url.hostname = "x.com";
+      url.search = "";
+    } else {
+      for (const key of [...url.searchParams.keys()]) {
+        if (/^(utm_|ref$|source$|fbclid$|gclid$)/i.test(key)) url.searchParams.delete(key);
+      }
+    }
+
+    return url.toString().replace(/\/$/, "");
   } catch {
     return value.trim().replace(/\/$/, "");
   }


### PR DESCRIPTION
Cleanup after the successful first automatic ingest:

- preserve meaningful query strings such as YouTube `?v=` instead of stripping them
- still canonicalize X/Twitter URLs for dedupe
- re-sync the source feed after ingest so `alreadyIngested`, `xCandidates`, and counts are immediately accurate

No change to the zero-touch publishing behavior.