### PR TITLE
feat: auto-ingest non-X awesome-grok-bot Field Cases

### DIFF
--- a/.github/workflows/awesome-grok-bot-auto-ingest.yml
+++ b/.github/workflows/awesome-grok-bot-auto-ingest.yml
@@ -9,6 +9,8 @@ on:
     paths:
       - "scripts/sync-awesome-grok-bot.mjs"
       - "scripts/ingest-awesome-grok-bot.ts"
+      - "lib/ingest/fetch-source-metadata.ts"
+      - "lib/ingest/validate.ts"
       - ".github/workflows/awesome-grok-bot-auto-ingest.yml"
 
 permissions:
@@ -40,10 +42,10 @@ jobs:
       - name: Sync Field Cases source feed
         run: node scripts/sync-awesome-grok-bot.mjs
 
-      - name: Auto-ingest X candidates
+      - name: Auto-ingest Field Case candidates
         run: npx tsx scripts/ingest-awesome-grok-bot.ts
         env:
-          SOURCE_INGEST_LIMIT: "10"
+          SOURCE_INGEST_LIMIT: "20"
           SOURCE_INGEST_MAX_ATTEMPTS: "3"
 
       - name: Refresh source status after ingest

--- a/lib/ingest/fetch-source-metadata.ts
+++ b/lib/ingest/fetch-source-metadata.ts
@@ -1,0 +1,245 @@
+export type GenericSourceType = "article" | "newsletter" | "youtube" | "github" | "note";
+
+export type GenericSourceMetadata = {
+  authorName: string;
+  publishedAt: string;
+  pageTitle?: string;
+  siteName: string;
+  dateFromSource: boolean;
+};
+
+const USER_AGENT = "UseGrokBot-source-ingest/1.0 (+https://usegrokbot.com)";
+
+function decodeHtml(value: string) {
+  return value
+    .replace(/&amp;/g, "&")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;|&#x27;/g, "'")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&nbsp;/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function isoDay(value?: string | null) {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toISOString().slice(0, 10);
+}
+
+function escaped(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function metaContent(html: string, key: string) {
+  const name = escaped(key);
+  const attrs = `(?:name|property|itemprop)=["']${name}["']`;
+  const patterns = [
+    new RegExp(`<meta[^>]+${attrs}[^>]+content="([^"]*)"[^>]*>`, "i"),
+    new RegExp(`<meta[^>]+${attrs}[^>]+content='([^']*)'[^>]*>`, "i"),
+    new RegExp(`<meta[^>]+content="([^"]*)"[^>]+${attrs}[^>]*>`, "i"),
+    new RegExp(`<meta[^>]+content='([^']*)'[^>]+${attrs}[^>]*>`, "i"),
+  ];
+  for (const pattern of patterns) {
+    const match = html.match(pattern);
+    if (match?.[1]) return decodeHtml(match[1]);
+  }
+  return null;
+}
+
+function htmlTitle(html: string) {
+  return (
+    metaContent(html, "og:title") ||
+    metaContent(html, "twitter:title") ||
+    decodeHtml(html.match(/<title[^>]*>([\s\S]*?)<\/title>/i)?.[1] ?? "") ||
+    undefined
+  );
+}
+
+function jsonLdAuthor(html: string) {
+  const object = html.match(/"author"\s*:\s*\{[\s\S]{0,800}?"name"\s*:\s*"([^"]+)"/i)?.[1];
+  const array = html.match(/"author"\s*:\s*\[[\s\S]{0,800}?"name"\s*:\s*"([^"]+)"/i)?.[1];
+  return decodeHtml(object || array || "") || null;
+}
+
+function dateFromHtml(html: string) {
+  const values = [
+    metaContent(html, "article:published_time"),
+    metaContent(html, "datePublished"),
+    metaContent(html, "date"),
+    metaContent(html, "pubdate"),
+    html.match(/"datePublished"\s*:\s*"([^"]+)"/i)?.[1],
+    html.match(/"publishDate"\s*:\s*"([^"]+)"/i)?.[1],
+    html.match(/"uploadDate"\s*:\s*"([^"]+)"/i)?.[1],
+  ];
+  for (const value of values) {
+    const day = isoDay(value);
+    if (day) return day;
+  }
+  return null;
+}
+
+function authorFromHtml(html: string) {
+  return (
+    metaContent(html, "author") ||
+    metaContent(html, "article:author") ||
+    jsonLdAuthor(html) ||
+    null
+  );
+}
+
+function inferAuthorFromIndexTitle(title: string) {
+  const colon = title.indexOf(":");
+  if (colon <= 0 || colon > 50) return null;
+  const candidate = title.slice(0, colon).trim();
+  return candidate && candidate.length <= 50 ? candidate : null;
+}
+
+function siteNameFromUrl(url: string, type: GenericSourceType) {
+  if (type === "youtube") return "YouTube";
+  if (type === "github") return "GitHub";
+  if (type === "note") return "note";
+  const host = new URL(url).hostname.replace(/^www\./, "");
+  return host;
+}
+
+async function fetchHtml(url: string) {
+  const response = await fetch(url, {
+    redirect: "follow",
+    headers: {
+      "User-Agent": USER_AGENT,
+      Accept: "text/html,application/xhtml+xml",
+    },
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (response.status === 404 || response.status === 410) {
+    throw new Error(`source_unreadable:${response.status}`);
+  }
+  if (!response.ok) return null;
+  const contentType = response.headers.get("content-type") ?? "";
+  if (!contentType.includes("text/html") && !contentType.includes("application/xhtml+xml")) return null;
+  return response.text();
+}
+
+async function youtubeMetadata(url: string, indexTitle: string): Promise<GenericSourceMetadata> {
+  let authorName = inferAuthorFromIndexTitle(indexTitle) || "YouTube creator";
+  let pageTitle: string | undefined;
+
+  try {
+    const response = await fetch(
+      `https://www.youtube.com/oembed?url=${encodeURIComponent(url)}&format=json`,
+      { headers: { "User-Agent": USER_AGENT }, signal: AbortSignal.timeout(10_000) },
+    );
+    if (response.ok) {
+      const data = (await response.json()) as { author_name?: string; title?: string };
+      authorName = data.author_name?.trim() || authorName;
+      pageTitle = data.title?.trim() || undefined;
+    }
+  } catch {
+    // The Field Cases index still gives us a source URL and CC0 summary.
+  }
+
+  let publishedAt: string | null = null;
+  try {
+    const html = await fetchHtml(url);
+    if (html) {
+      publishedAt = dateFromHtml(html);
+      pageTitle = pageTitle || htmlTitle(html);
+    }
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("source_unreadable:")) throw error;
+  }
+
+  return {
+    authorName,
+    pageTitle,
+    publishedAt: publishedAt ?? new Date().toISOString().slice(0, 10),
+    siteName: "YouTube",
+    dateFromSource: Boolean(publishedAt),
+  };
+}
+
+async function githubMetadata(url: string, indexTitle: string): Promise<GenericSourceMetadata> {
+  const parsed = new URL(url);
+  const parts = parsed.pathname.split("/").filter(Boolean);
+  const owner = parts[0] || inferAuthorFromIndexTitle(indexTitle) || "GitHub contributor";
+  const repo = parts[1];
+  if (!repo) {
+    return {
+      authorName: owner,
+      publishedAt: new Date().toISOString().slice(0, 10),
+      siteName: "GitHub",
+      dateFromSource: false,
+    };
+  }
+
+  try {
+    const response = await fetch(`https://api.github.com/repos/${owner}/${repo}`, {
+      headers: { "User-Agent": USER_AGENT, Accept: "application/vnd.github+json" },
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (response.status === 404) throw new Error("source_unreadable:404");
+    if (response.ok) {
+      const data = (await response.json()) as {
+        owner?: { login?: string };
+        created_at?: string;
+        full_name?: string;
+      };
+      const day = isoDay(data.created_at);
+      return {
+        authorName: data.owner?.login || owner,
+        pageTitle: data.full_name,
+        publishedAt: day ?? new Date().toISOString().slice(0, 10),
+        siteName: "GitHub",
+        dateFromSource: Boolean(day),
+      };
+    }
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("source_unreadable:")) throw error;
+  }
+
+  return {
+    authorName: owner,
+    publishedAt: new Date().toISOString().slice(0, 10),
+    siteName: "GitHub",
+    dateFromSource: false,
+  };
+}
+
+export async function fetchGenericSourceMetadata(
+  url: string,
+  type: GenericSourceType,
+  indexTitle: string,
+): Promise<GenericSourceMetadata> {
+  if (type === "youtube") return youtubeMetadata(url, indexTitle);
+  if (type === "github") return githubMetadata(url, indexTitle);
+
+  const fallbackAuthor = inferAuthorFromIndexTitle(indexTitle);
+  const fallbackSite = siteNameFromUrl(url, type);
+
+  try {
+    const html = await fetchHtml(url);
+    if (html) {
+      const siteName = metaContent(html, "og:site_name") || fallbackSite;
+      const publishedAt = dateFromHtml(html);
+      return {
+        authorName: authorFromHtml(html) || fallbackAuthor || siteName,
+        pageTitle: htmlTitle(html),
+        publishedAt: publishedAt ?? new Date().toISOString().slice(0, 10),
+        siteName,
+        dateFromSource: Boolean(publishedAt),
+      };
+    }
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("source_unreadable:")) throw error;
+  }
+
+  return {
+    authorName: fallbackAuthor || fallbackSite,
+    publishedAt: new Date().toISOString().slice(0, 10),
+    siteName: fallbackSite,
+    dateFromSource: false,
+  };
+}

--- a/lib/ingest/validate.ts
+++ b/lib/ingest/validate.ts
@@ -32,6 +32,26 @@ function normalizeQuote(value: string) {
   return value.replace(/\s+/g, " ").trim().toLowerCase();
 }
 
+function canonicalSourceUrl(value: string) {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+    url.hash = "";
+    const host = url.hostname.replace(/^www\./, "");
+    if (host === "twitter.com" || host === "x.com") {
+      url.hostname = "x.com";
+      url.search = "";
+    } else {
+      for (const key of [...url.searchParams.keys()]) {
+        if (/^(utm_|ref$|source$|fbclid$|gclid$)/i.test(key)) url.searchParams.delete(key);
+      }
+    }
+    return url.toString().replace(/\/$/, "");
+  } catch {
+    return null;
+  }
+}
+
 export function existingStoryKeys(stories: DiscoverStory[] = discoverStories) {
   const slugs = new Set(stories.map((item) => item.slug));
   const tweetIds = new Set(
@@ -130,5 +150,19 @@ export function assertStorySafe(story: DiscoverStory, stories: DiscoverStory[] =
     throw new Error(`Unknown related use case: ${story.relatedUseCase}`);
   }
   if (!story.result && !story.output) throw new Error("Story needs result or output.");
-  if (!story.xPostUrl || !tweetIdFromUrl(story.xPostUrl)) throw new Error("Story needs a real X permalink.");
+
+  const sourceUrl = canonicalSourceUrl(story.sourceUrl);
+  if (!sourceUrl) throw new Error("Story needs a real HTTP(S) source URL.");
+
+  if (story.xPostUrl) {
+    if (!tweetIdFromUrl(story.xPostUrl)) throw new Error("xPostUrl must be a real X permalink.");
+  } else if (tweetIdFromUrl(story.sourceUrl)) {
+    throw new Error("X sources must set xPostUrl.");
+  }
+
+  const duplicateSource = stories.some((item) => {
+    const candidates = [item.sourceUrl, item.xPostUrl].filter(Boolean) as string[];
+    return candidates.some((candidate) => canonicalSourceUrl(candidate) === sourceUrl);
+  });
+  if (duplicateSource) throw new Error(`Duplicate source: ${story.sourceUrl}`);
 }

--- a/scripts/ingest-awesome-grok-bot.ts
+++ b/scripts/ingest-awesome-grok-bot.ts
@@ -1,5 +1,6 @@
 import { readFile, writeFile } from "node:fs/promises";
 import { discoverStories, type DiscoverStory } from "../data/discover";
+import { fetchGenericSourceMetadata, type GenericSourceType } from "../lib/ingest/fetch-source-metadata";
 import { fetchXPost, type FetchedPost } from "../lib/ingest/fetch-post";
 import { makeStorySlug } from "../lib/ingest/slug";
 import { assertStorySafe } from "../lib/ingest/validate";
@@ -7,7 +8,7 @@ import { site } from "../lib/site";
 
 const FEED_PATH = "data/source-feeds/awesome-grok-bot-field-cases.json";
 const INGESTED_PATH = "data/discover/ingested.json";
-const MAX_PER_RUN = Math.max(1, Number(process.env.SOURCE_INGEST_LIMIT ?? "10"));
+const MAX_PER_RUN = Math.max(1, Number(process.env.SOURCE_INGEST_LIMIT ?? "20"));
 const MAX_ATTEMPTS = Math.max(1, Number(process.env.SOURCE_INGEST_MAX_ATTEMPTS ?? "3"));
 const RETRYABLE = new Set([
   "source_unreadable",
@@ -48,6 +49,18 @@ type ExtractResponse = {
   reason?: string;
 };
 
+const GENERIC_SOURCE_TYPES = new Set<GenericSourceType>([
+  "article",
+  "newsletter",
+  "youtube",
+  "github",
+  "note",
+]);
+
+function isGenericSourceType(value: string): value is GenericSourceType {
+  return GENERIC_SOURCE_TYPES.has(value as GenericSourceType);
+}
+
 async function saveFeed(feed: Feed) {
   await writeFile(FEED_PATH, `${JSON.stringify(feed, null, 2)}\n`, "utf8");
 }
@@ -57,9 +70,13 @@ async function saveIngested(stories: DiscoverStory[]) {
 }
 
 function shouldProcess(item: SourceCase) {
-  if (item.sourceType !== "x" || item.sourceStatus !== "candidate") return false;
+  if (item.sourceStatus !== "candidate") return false;
+  if (item.sourceType !== "x" && !isGenericSourceType(item.sourceType)) return false;
   const recoverOldPermissionFailure = item.ingest.status === "skipped" && item.ingest.code === "github_403";
-  if (!["pending", "retry"].includes(item.ingest.status) && !recoverOldPermissionFailure) return false;
+  const legacySourceOnly = item.ingest.status === "source-only";
+  if (!["pending", "retry"].includes(item.ingest.status) && !recoverOldPermissionFailure && !legacySourceOnly) {
+    return false;
+  }
   return (item.ingest.attempts ?? 0) < MAX_ATTEMPTS;
 }
 
@@ -111,7 +128,8 @@ function fallbackTitle(item: SourceCase) {
 function fallbackCategory(text: string): DiscoverStory["category"] {
   const value = text.toLowerCase();
   if (/wordpress|arduino|engineering|\bpr\b|databricks|developer|technical|code|software/.test(value)) return "coding";
-  if (/market|research|brief|scan|reconcile|credit/.test(value)) return "research";
+  if (/support|helpdesk|customer[- ]service/.test(value)) return "operations";
+  if (/market|research|brief|scan|reconcile|credit|field notes/.test(value)) return "research";
   if (/calendar|reservation|travel|shopping|flights|beer|personal/.test(value)) return "personal";
   if (/sales|buyer|lead|customer/.test(value)) return "sales";
   if (/content|image|write|video|post/.test(value)) return "content";
@@ -145,7 +163,7 @@ function fallbackApps(text: string): DiscoverStory["apps"] {
   if (/\blinkedin\b/.test(value)) add("linkedin");
   if (/\breddit\b/.test(value)) add("reddit");
   if (/\byoutube\b/.test(value)) add("youtube");
-  if (/\bbrowser\b|website|site\b/.test(value)) add("browser");
+  if (/\bbrowser\b|website|site\b|airline/.test(value)) add("browser");
   if (/\bx\b|twitter/.test(value)) add("x");
 
   return apps;
@@ -178,7 +196,7 @@ function audienceFor(category: DiscoverStory["category"]) {
   }
 }
 
-function buildSafeFallback(item: SourceCase, post: FetchedPost, existingStories: DiscoverStory[]): DiscoverStory {
+function buildSafeXFallback(item: SourceCase, post: FetchedPost, existingStories: DiscoverStory[]): DiscoverStory {
   const title = fallbackTitle(item);
   const combined = `${item.title}\n${item.sourceSummary}\n${post.sourceText}`;
   const category = fallbackCategory(combined);
@@ -214,9 +232,65 @@ function buildSafeFallback(item: SourceCase, post: FetchedPost, existingStories:
   };
 }
 
-async function safeFallback(item: SourceCase, existingStories: DiscoverStory[]) {
+async function safeXFallback(item: SourceCase, existingStories: DiscoverStory[]) {
   const post = await fetchXPost(item.url);
-  return buildSafeFallback(item, post, existingStories);
+  return buildSafeXFallback(item, post, existingStories);
+}
+
+function sourceTypeLabel(type: GenericSourceType) {
+  switch (type) {
+    case "youtube":
+      return "YouTube";
+    case "github":
+      return "GitHub";
+    case "newsletter":
+      return "Newsletter";
+    case "note":
+      return "Article";
+    default:
+      return "Article";
+  }
+}
+
+async function buildGenericSourceStory(item: SourceCase, existingStories: DiscoverStory[]): Promise<DiscoverStory> {
+  if (!isGenericSourceType(item.sourceType)) throw new Error(`unsupported_source:${item.sourceType}`);
+
+  const metadata = await fetchGenericSourceMetadata(item.url, item.sourceType, item.title);
+  const title = fallbackTitle(item);
+  const combined = `${item.title}\n${item.sourceSummary}\n${metadata.pageTitle ?? ""}`;
+  const category = fallbackCategory(combined);
+  const whoShouldTry = audienceFor(category);
+  const sourceKind = sourceTypeLabel(item.sourceType);
+  const slug = makeStorySlug(metadata.authorName, title, new Set(existingStories.map((story) => story.slug)));
+  const dateNote = metadata.dateFromSource
+    ? "The publication date comes from machine-readable metadata on the original source."
+    : "The source did not expose a reliable machine-readable publication date, so the displayed date is when UseGrokBot indexed it.";
+
+  return {
+    slug,
+    title,
+    headline: item.sourceSummary,
+    whatTheyDid: item.sourceSummary,
+    howItWorks:
+      `This public ${sourceKind.toLowerCase()} was surfaced through the awesome-grok-bot Field Cases index. UseGrokBot uses the CC0 index summary plus source metadata, links to the original, and does not copy the source body. ${dateNote}`,
+    whyUseful:
+      "It is a public field example of Grok Bot being used for a real task, preserved here as a short discovery card with the original source one click away.",
+    whyItMatters:
+      "UseGrokBot can now discover useful cases beyond X without mirroring the original article, video, newsletter or repository. The linked source remains the authority for the full context.",
+    whoShouldTry,
+    usefulFor: whoShouldTry.join(" / "),
+    output: item.sourceSummary,
+    category,
+    outcomes: fallbackOutcomes(category),
+    apps: fallbackApps(combined),
+    difficulty: "medium",
+    schedule: fallbackSchedule(combined),
+    source: "community",
+    authorName: metadata.authorName,
+    publishedAt: metadata.publishedAt,
+    sourceUrl: item.url,
+    sourceLabel: `${metadata.authorName} · ${metadata.siteName || sourceKind}`,
+  };
 }
 
 function parseFailure(error: unknown) {
@@ -229,11 +303,10 @@ function parseFailure(error: unknown) {
   };
 }
 
-async function getStory(item: SourceCase, existingStories: DiscoverStory[]) {
-  // These entries already reached the publish step, so do not burn another AI call.
+async function getXStory(item: SourceCase, existingStories: DiscoverStory[]) {
   if (["extract_failed", "github_403"].includes(item.ingest.code ?? "")) {
-    console.log("Using safe source-index fallback for a previously attempted case.");
-    return safeFallback(item, existingStories);
+    console.log("Using safe source-index fallback for a previously attempted X case.");
+    return safeXFallback(item, existingStories);
   }
 
   try {
@@ -242,10 +315,15 @@ async function getStory(item: SourceCase, existingStories: DiscoverStory[]) {
     const failure = parseFailure(error);
     if (["extract_failed", "site_extract_failed", "rate_limited"].includes(failure.code)) {
       console.log(`${failure.code}; using safe source-index fallback.`);
-      return safeFallback(item, existingStories);
+      return safeXFallback(item, existingStories);
     }
     throw error;
   }
+}
+
+async function getStory(item: SourceCase, existingStories: DiscoverStory[]) {
+  if (item.sourceType === "x") return getXStory(item, existingStories);
+  return buildGenericSourceStory(item, existingStories);
 }
 
 async function main() {
@@ -255,16 +333,16 @@ async function main() {
   const queue = feed.cases.filter(shouldProcess).slice(0, MAX_PER_RUN);
 
   if (!queue.length) {
-    console.log("No new X Field Cases to ingest.");
+    console.log("No new Field Cases to ingest.");
     return;
   }
 
-  console.log(`Auto-ingesting ${queue.length} X Field Cases from awesome-grok-bot.`);
+  console.log(`Auto-ingesting ${queue.length} Field Cases from awesome-grok-bot.`);
 
   for (const candidate of queue) {
     const item = feed.cases.find((entry) => entry.url === candidate.url)!;
     const attempts = (item.ingest.attempts ?? 0) + 1;
-    console.log(`\n[${attempts}/${MAX_ATTEMPTS}] ${item.title}\n${item.url}`);
+    console.log(`\n[${attempts}/${MAX_ATTEMPTS}] [${item.sourceType}] ${item.title}\n${item.url}`);
 
     try {
       if (workingStories.some((story) => story.xPostUrl === item.url || story.sourceUrl === item.url)) {

--- a/scripts/sync-awesome-grok-bot.mjs
+++ b/scripts/sync-awesome-grok-bot.mjs
@@ -42,6 +42,7 @@ function sourceType(url) {
   const host = new URL(url).hostname.replace(/^www\./, "");
   if (host === "x.com" || host === "twitter.com") return "x";
   if (host === "youtube.com" || host === "youtu.be") return "youtube";
+  if (host === "github.com") return "github";
   if (host.endsWith("substack.com")) return "newsletter";
   if (host === "note.com") return "note";
   return "article";
@@ -111,9 +112,17 @@ async function main() {
     const alreadyIngested = existingUrls.has(item.url);
     const old = previousByUrl.get(item.url);
     const oldIngest = old?.ingest && typeof old.ingest === "object" ? old.ingest : undefined;
-    const ingest = alreadyIngested
-      ? { status: "published", attempts: oldIngest?.attempts ?? 0 }
-      : oldIngest ?? { status: type === "x" ? "pending" : "source-only", attempts: 0 };
+
+    let ingest;
+    if (alreadyIngested) {
+      ingest = { status: "published", attempts: oldIngest?.attempts ?? 0 };
+    } else if (oldIngest?.status === "source-only") {
+      // V2 stored non-X links without processing them. V3 promotes them into the
+      // same zero-touch queue used by X cases.
+      ingest = { status: "pending", attempts: oldIngest?.attempts ?? 0 };
+    } else {
+      ingest = oldIngest ?? { status: "pending", attempts: 0 };
+    }
 
     return {
       id: slugify(item.title),
@@ -128,21 +137,22 @@ async function main() {
   });
 
   const payload = {
-    schemaVersion: 2,
+    schemaVersion: 3,
     source: {
       name: "awesome-grok-bot Field Cases",
       repository: "https://github.com/RongleCat/awesome-grok-bot",
       rawReadme: README_URL,
       section: "Field Cases",
       sourceListLicense: "CC0-1.0",
-      note: "The list metadata is CC0. Linked X posts, articles, videos and other source content retain their own rights. UseGrokBot summarizes the original source and links back rather than copying it wholesale.",
+      note: "The list metadata is CC0. Linked X posts, articles, videos, repositories and other source content retain their own rights. UseGrokBot uses the index as a discovery source, summarizes conservatively, and links back rather than copying source content wholesale.",
     },
     stats: {
       total: cases.length,
       candidates: cases.filter((item) => item.sourceStatus === "candidate").length,
       xCandidates: cases.filter((item) => item.sourceStatus === "candidate" && item.sourceType === "x").length,
+      nonXCandidates: cases.filter((item) => item.sourceStatus === "candidate" && item.sourceType !== "x").length,
       alreadyIngested: cases.filter((item) => item.sourceStatus === "already-ingested").length,
-      sourceOnly: cases.filter((item) => item.ingest.status === "source-only").length,
+      pending: cases.filter((item) => ["pending", "retry"].includes(item.ingest.status)).length,
     },
     cases,
   };
@@ -150,13 +160,15 @@ async function main() {
   await mkdir(dirname(OUTPUT_PATH), { recursive: true });
   const next = `${JSON.stringify(payload, null, 2)}\n`;
   if (previousSource === next) {
-    console.log(`No source-feed changes. ${payload.stats.total} Field Cases, ${payload.stats.xCandidates} X candidates.`);
+    console.log(
+      `No source-feed changes. ${payload.stats.total} Field Cases, ${payload.stats.xCandidates} X candidates, ${payload.stats.nonXCandidates} non-X candidates.`,
+    );
     return;
   }
 
   await writeFile(OUTPUT_PATH, next, "utf8");
   console.log(
-    `Updated ${OUTPUT_PATH}: ${payload.stats.total} total, ${payload.stats.xCandidates} X candidates, ${payload.stats.alreadyIngested} already ingested.`,
+    `Updated ${OUTPUT_PATH}: ${payload.stats.total} total, ${payload.stats.xCandidates} X candidates, ${payload.stats.nonXCandidates} non-X candidates, ${payload.stats.alreadyIngested} already ingested.`,
   );
 }
 


### PR DESCRIPTION
## What this adds

The `awesome-grok-bot` source feed can now ingest more than X posts.

Supported source types:
- Articles / blogs
- Newsletters / Substack
- YouTube
- GitHub repositories
- note.com / article-style sources
- X (existing path remains)

## Safety

- Uses the CC0 Field Cases title/summary as the conservative content layer
- Reads only source metadata (author/date/title/site) for non-X pages
- Does not copy article/video/newsletter bodies
- Keeps the original source URL as the authority
- Never invents result numbers or quotes
- X sources still require a real X permalink
- Non-X sources require a real HTTP(S) source and are deduplicated by source URL

## Automation

Every 6 hours:

`awesome-grok-bot → sync → queue all source types → metadata/source checks → generate case → validate → direct commit → Vercel`

No human approval.