### PR TITLE
docs: document live multi-source ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # UseGrokBot
 
 <p align="center">
-  <strong>Discover real Grok Bot workflows from X — then build them yourself.</strong>
+  <strong>Discover real Grok Bot workflows from the public web — then build them yourself.</strong>
 </p>
 
 <p align="center">
@@ -24,7 +24,7 @@
 
 UseGrokBot is an open-source discovery hub for real Grok Bot use cases.
 
-Instead of dumping prompts into a directory, UseGrokBot starts with real examples shared publicly by the Grok Bot community, keeps attribution to the original source, explains what was built in plain language, and connects useful examples to ready-to-build workflows.
+Instead of dumping prompts into a directory, UseGrokBot starts with public examples from X and the wider web, keeps attribution to the original source, explains what was built in plain language, and connects useful examples to ready-to-build workflows.
 
 ```text
 Discover → Understand → Build → Copy → Share
@@ -32,8 +32,8 @@ Discover → Understand → Build → Copy → Share
 
 ## Why UseGrokBot?
 
-- **Real examples** — discover public Grok Bot use cases from X and the wider community.
-- **Original attribution** — community cases link back to the original author and source.
+- **Real examples** — public Grok Bot use cases from X, articles, videos, newsletters, GitHub, and community writeups.
+- **Original attribution** — every community case links back to the original source.
 - **Plain-English explanations** — understand what the Bot actually did and why it matters.
 - **Buildable workflows** — turn an interesting example into a reusable workflow and prompt.
 - **Integrations** — browse workflows by the apps and tools you already use.
@@ -48,11 +48,11 @@ UseGrokBot distinguishes between different levels of verification:
 - 🧪 **Tested** — tested by UseGrokBot.
 - 👥 **Community** — shared publicly by the community and linked back to the original source.
 
-We do not invent result numbers. If the original source does not provide a measurable result, the case should be described as an **Output** instead.
+We do not invent result numbers. If the original source does not provide a measurable result, the case is described as an **Output** instead.
 
 ## Community-powered discovery
 
-Useful Grok Bot examples are spread across X, tutorials, videos, GitHub repositories, and community writeups. UseGrokBot turns those scattered signals into a structured discovery layer.
+Useful Grok Bot examples are spread across X, tutorials, videos, GitHub repositories, newsletters, and community writeups. UseGrokBot turns those scattered signals into a structured discovery layer.
 
 A public source can become:
 
@@ -72,25 +72,40 @@ Related build guide
 
 Useful public indexes such as [`awesome-grok-bot`](https://github.com/RongleCat/awesome-grok-bot) can act as discovery sources, while UseGrokBot still links to and attributes the original underlying source.
 
-## Automatic source ingestion
+## Zero-touch automatic source ingestion
 
 UseGrokBot watches the **Field Cases** section of [`RongleCat/awesome-grok-bot`](https://github.com/RongleCat/awesome-grok-bot) every 6 hours.
+
+Supported source types include:
+
+- X posts
+- Articles / blogs
+- Newsletters / Substack
+- YouTube videos
+- GitHub repositories
+- note.com / article-style sources
 
 ```text
 awesome-grok-bot / Field Cases
           ↓
 Source feed + URL dedupe
           ↓
-X cases → existing machine-ingest pipeline
+X / Article / Video / Newsletter / GitHub
           ↓
-AI relevance + metadata extraction
+Metadata + source checks
           ↓
-Source / attribution / result validation
+Conservative structured case
           ↓
-PR → auto-merge → Discover
+Discover validation
+          ↓
+Direct automated commit
+          ↓
+Vercel deployment
 ```
 
-Non-X Field Cases (articles, videos, newsletters, notes) remain in the machine-readable source feed until generic-source ingestion supports them.
+For X cases, UseGrokBot prefers the machine extraction path and falls back to a conservative source-index summary if AI extraction is unavailable.
+
+For non-X cases, the ingestion worker reads source metadata such as author, date, page title, site name, YouTube oEmbed data, or public GitHub repository metadata. It **does not copy article, video, newsletter, or repository bodies** into UseGrokBot.
 
 The synced source index lives at:
 
@@ -98,14 +113,34 @@ The synced source index lives at:
 data/source-feeds/awesome-grok-bot-field-cases.json
 ```
 
+The structured machine-ingested cases live at:
+
+```text
+data/discover/ingested.json
+```
+
 Local commands:
 
 ```bash
 npm run sync:awesome-grok-bot
 npm run ingest:awesome-grok-bot
+npm run validate:discover
 ```
 
-The source feed is an index of candidates, not permission to republish linked content. UseGrokBot summarizes the original source, preserves attribution, and links back.
+The source feed is an index of candidates, not permission to republish linked content. UseGrokBot summarizes conservatively, preserves attribution, and links back to the original source.
+
+## Safety rules for ingestion
+
+Automated ingestion must preserve a few hard rules:
+
+- Keep the original source URL.
+- Do not invent numeric results.
+- Do not invent quotes.
+- Do not mark automatically ingested cases as Tested, Featured, or Trending.
+- X cases require a real X permalink.
+- Non-X cases require a real HTTP(S) source URL.
+- Duplicate source URLs are rejected.
+- Linked third-party content keeps its original rights.
 
 ## Project structure
 
@@ -125,6 +160,7 @@ public/       Static assets
 - TypeScript
 - Tailwind CSS 4
 - Vercel deployment
+- GitHub Actions
 - Structured local content
 
 ## Local development
@@ -143,9 +179,10 @@ npm run lint
 npm run build
 npm run validate:discover
 npm run sync:awesome-grok-bot
+npm run ingest:awesome-grok-bot
 ```
 
-The fastest way to add a public example is [Submit a use case](https://usegrokbot.com/submit). Paste the X post. A machine extracts the rest, validates it, and publishes if it passes.
+The fastest way to submit a public X example is [Submit a use case](https://usegrokbot.com/submit). Paste the X post and the machine handles the rest if it passes validation.
 
 ## Contributing
 
@@ -158,27 +195,15 @@ You can help by:
 - improving Traditional / Simplified Chinese translations
 - fixing mobile UX or accessibility issues
 - improving workflow guides
+- adding a public source index
+- improving source metadata extraction
 - fixing bugs or documentation
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the contribution rules.
 
 ## Roadmap
 
-X post submissions and the `awesome-grok-bot` X Field Cases source now run through the machine-ingest loop. Generic article / video sources are next:
-
-```text
-X / public source
-      ↓
-AI relevance + metadata extraction
-      ↓
-Source / duplicate / evidence validation
-      ↓
-Structured case
-      ↓
-CI validation
-      ↓
-Publish
-```
+Multi-source ingestion is now live. The next ingestion priorities are additional public source indexes, `@UseGrokBot` mention ingestion, semantic duplicate detection, and better integration mapping.
 
 See [ROADMAP.md](ROADMAP.md) for planned work.
 
@@ -188,7 +213,7 @@ The code in this repository is licensed under the [MIT License](LICENSE).
 
 The MIT license covers the software code. The **UseGrokBot** name, logo, and project branding remain associated with this project and are not a grant of trademark rights.
 
-Third-party posts, screenshots, articles, videos, logos, names, and other linked materials remain the property of their respective owners and are used only as sources / references where applicable.
+Third-party posts, screenshots, articles, videos, logos, names, repositories, and other linked materials remain the property of their respective owners and are used only as sources / references where applicable.
 
 ## Disclaimer
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,22 +16,29 @@ The long-term goal is simple:
 - [x] Submission page
 - [x] Open-source repository
 - [x] MIT license
-- [x] X-post machine ingestion: extract, validate, PR, auto-merge
+- [x] X-post machine ingestion: extract, validate, publish
 - [x] Automatic source feed: `awesome-grok-bot` Field Cases every 6 hours
-- [x] Auto-ingest new X Field Cases through the existing machine-ingest pipeline
+- [x] Auto-ingest X Field Cases
+- [x] Auto-ingest article / blog Field Cases
+- [x] Auto-ingest newsletter / Substack Field Cases
+- [x] Auto-ingest YouTube Field Cases
+- [x] Auto-ingest GitHub repository Field Cases
+- [x] Auto-ingest note.com / article-style Field Cases
+- [x] Metadata extraction for non-X sources: author, date, title, site
+- [x] URL dedupe across X and non-X sources
 - [ ] Improve discover cards with stronger Result / Output presentation
 - [ ] Improve mobile filter density and touch targets
 - [ ] Expand trust labels: Official / Tested / Community
 - [ ] Improve integration filtering and landing pages
 
-## Next: automated ingestion
+## Automated ingestion
 
 The main product direction is a **zero-touch ingestion pipeline**.
 
 ```text
-X / public source
+X / article / video / newsletter / GitHub / public source
       ↓
-Relevance detection
+Source discovery
       ↓
 Metadata extraction
       ↓
@@ -39,36 +46,45 @@ Attribution + source validation
       ↓
 Duplicate detection
       ↓
-Result evidence validation
+Conservative summary / output
       ↓
 Structured discover case
       ↓
 CI validation
       ↓
-Publish
+Direct automated publish
 ```
 
-Planned work:
+Live today:
 
-- [x] Monitor a public Grok Bot source for candidate cases (`awesome-grok-bot` Field Cases)
+- [x] Monitor `awesome-grok-bot` Field Cases every 6 hours
 - [x] Parse submitted public X URLs
 - [x] Extract author, handle, date, integrations, category, and outcome from X
+- [x] Read author / date / title / site metadata from non-X sources
+- [x] Use YouTube oEmbed metadata where available
+- [x] Read public GitHub repository metadata where available
 - [x] Detect duplicate X post IDs automatically
+- [x] Detect duplicate source URLs automatically
 - [x] Separate verified numeric `Result` from non-numeric `Output` for X ingest
 - [x] Reject unsupported result numbers automatically
+- [x] Keep non-X ingestion conservative: no copied article/video body, no invented quotes or result numbers
 - [x] Generate structured ingested DiscoverStory content
 - [x] Add automated CI content validation
-- [x] Auto-publish X cases that pass validation
-- [x] Keep failed X cases in an error queue instead of blocking normal ingestion
+- [x] Auto-publish cases that pass validation
+- [x] Keep transient failures retryable instead of blocking normal ingestion
+
+Next ingestion work:
+
 - [ ] Add more public source indexes / feeds
-- [ ] Add generic article / newsletter / video source ingestion
 - [ ] Parse X mentions such as `@UseGrokBot`
 - [ ] Detect semantic duplicates across different source URLs
+- [ ] Improve source-date recovery for pages without machine-readable publication dates
+- [ ] Map more detected tools into integrations automatically
 
 ## Community
 
-- [ ] Add issue templates
-- [ ] Add pull request template
+- [ ] Add / improve issue templates
+- [ ] Add / improve pull request template
 - [ ] Add `good first issue` tasks
 - [ ] Add `help wanted` tasks
 - [ ] Make it easier to contribute one integration or one public example
@@ -117,7 +133,7 @@ Sponsored content should always be clearly labeled and should not change editori
 
 1. **Original source first** — link back to the creator.
 2. **No fake numbers** — never invent results.
-3. **Explain, don't mirror** — add useful context instead of copying posts.
+3. **Explain, don't mirror** — add useful context instead of copying posts, articles, videos, or newsletters.
 4. **Buildable** — connect discovery to workflows whenever possible.
 5. **Automation over manual ops** — normal ingestion should not require human approval.
 6. **Exceptions, not queues** — humans handle failures, not every item.


### PR DESCRIPTION
Update the public open-source docs now that generic source ingestion is live.

- README now documents X + articles + newsletters + YouTube + GitHub + note.com ingestion
- Explains metadata-only/non-mirroring safety rules
- Documents the zero-touch GitHub Actions → Vercel flow
- ROADMAP marks generic-source ingestion complete and moves more source indexes / X mentions / semantic dedupe into Next

No product UI changes.