### PR TITLE
feat: add Blobatar community identities and profiles

### DIFF
--- a/app/[locale]/community/[handle]/page.tsx
+++ b/app/[locale]/community/[handle]/page.tsx
@@ -29,7 +29,7 @@ export default async function CommunityProfilePage({
   const decoded = decodeURIComponent(handle).toLowerCase();
   const stories = discoverStories
     .filter((item) => item.handle?.toLowerCase() === decoded)
-    .toSorted((a, b) => b.publishedAt.localeCompare(a.publishedAt));
+    .sort((a, b) => b.publishedAt.localeCompare(a.publishedAt));
 
   if (!stories.length) notFound();
 

--- a/app/[locale]/community/[handle]/page.tsx
+++ b/app/[locale]/community/[handle]/page.tsx
@@ -1,0 +1,96 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { BlobatarAvatar } from "@/components/BlobatarAvatar";
+import { DiscoverCard } from "@/components/DiscoverCard";
+import { discoverStories } from "@/data/discover";
+import { site } from "@/lib/site";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string; handle: string }>;
+}): Promise<Metadata> {
+  const { handle } = await params;
+  const decoded = decodeURIComponent(handle).toLowerCase();
+  const story = discoverStories.find((item) => item.handle?.toLowerCase() === decoded);
+  if (!story) return { title: `Community | ${site.name}` };
+  return {
+    title: `${story.authorName} (@${story.handle}) | ${site.name}`,
+    description: `Public Grok Bot examples shared by ${story.authorName}, curated by UseGrokBot with links to the original source.`,
+  };
+}
+
+export default async function CommunityProfilePage({
+  params,
+}: {
+  params: Promise<{ locale: string; handle: string }>;
+}) {
+  const { locale, handle } = await params;
+  const decoded = decodeURIComponent(handle).toLowerCase();
+  const stories = discoverStories
+    .filter((item) => item.handle?.toLowerCase() === decoded)
+    .toSorted((a, b) => b.publishedAt.localeCompare(a.publishedAt));
+
+  if (!stories.length) notFound();
+
+  const first = stories[0];
+  const actualHandle = first.handle!;
+  const copy = profileCopy(locale, stories.length);
+
+  return (
+    <div className="mx-auto max-w-[1120px] px-5 py-12 md:px-8 md:py-16">
+      <div className="flex flex-col gap-5 sm:flex-row sm:items-center">
+        <BlobatarAvatar name={actualHandle} size={88} expression="love" />
+        <div className="min-w-0">
+          <p className="text-[12px] font-medium tracking-[0.08em] text-faint uppercase">{copy.identity}</p>
+          <h1 className="mt-1 text-[clamp(28px,5vw,44px)] font-medium tracking-tight text-ink">{first.authorName}</h1>
+          <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-mute">
+            <span>@{actualHandle}</span>
+            <span>{copy.count}</span>
+            <a
+              href={`https://x.com/${encodeURIComponent(actualHandle)}`}
+              target="_blank"
+              rel="noreferrer"
+              className="hover:text-ink"
+            >
+              {copy.xProfile} ↗
+            </a>
+          </div>
+        </div>
+      </div>
+
+      <p className="mt-8 max-w-2xl text-sm leading-6 text-mute">{copy.body}</p>
+
+      <div className="mt-8 grid gap-5 sm:grid-cols-2 xl:grid-cols-3">
+        {stories.map((story) => (
+          <DiscoverCard key={story.slug} story={story} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function profileCopy(locale: string, count: number) {
+  if (locale === "zh-hk") {
+    return {
+      identity: "Community Blob Identity",
+      count: `${count} 個公開案例`,
+      xProfile: "X Profile",
+      body: "呢頁集合呢位作者喺 UseGrokBot 出現過嘅公開 Grok Bot 案例。Blob 只係社群身份；每個案例仍然保留原始來源同作者 attribution。",
+    };
+  }
+  if (locale === "zh-cn") {
+    return {
+      identity: "Community Blob Identity",
+      count: `${count} 个公开案例`,
+      xProfile: "X Profile",
+      body: "这个页面集合该作者在 UseGrokBot 出现过的公开 Grok Bot 案例。Blob 只是社区身份；每个案例仍然保留原始来源和作者 attribution。",
+    };
+  }
+  return {
+    identity: "Community Blob Identity",
+    count: `${count} public ${count === 1 ? "case" : "cases"}`,
+    xProfile: "X profile",
+    body: "This page groups the public Grok Bot examples attributed to this author on UseGrokBot. The Blob is only a community identity; every case still keeps its original source and attribution.",
+  };
+}

--- a/app/[locale]/community/page.tsx
+++ b/app/[locale]/community/page.tsx
@@ -1,0 +1,82 @@
+import type { Metadata } from "next";
+import { CommunityView, type CommunityIdentity, type GitHubContributor } from "@/components/CommunityView";
+import { discoverStories } from "@/data/discover";
+import { site } from "@/lib/site";
+
+export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }): Promise<Metadata> {
+  const { locale } = await params;
+  const title = locale === "zh-hk" ? "社群" : locale === "zh-cn" ? "社区" : "Community";
+  const description =
+    locale === "zh-hk"
+      ? "認識分享 Grok Bot 真實案例嘅社群，同埋幫手改善 UseGrokBot 嘅開源 Contributor。"
+      : locale === "zh-cn"
+        ? "认识分享 Grok Bot 真实案例的社区，以及帮助改善 UseGrokBot 的开源 Contributor。"
+        : "Meet the community sharing real Grok Bot examples and the open-source contributors improving UseGrokBot.";
+  return { title: `${title} | ${site.name}`, description };
+}
+
+export default async function CommunityPage() {
+  const [contributors] = await Promise.all([getContributors()]);
+  return <CommunityView identities={communityIdentities()} contributors={contributors} />;
+}
+
+function communityIdentities(): CommunityIdentity[] {
+  const grouped = new Map<string, CommunityIdentity>();
+
+  for (const story of discoverStories) {
+    if (story.source !== "community") continue;
+    const key = (story.handle ?? story.authorName).trim().toLowerCase();
+    if (!key) continue;
+    const current = grouped.get(key);
+    if (!current) {
+      grouped.set(key, {
+        name: story.authorName,
+        handle: story.handle,
+        count: 1,
+        latest: story.publishedAt,
+      });
+      continue;
+    }
+    current.count += 1;
+    if (story.publishedAt > current.latest) current.latest = story.publishedAt;
+    if (!current.handle && story.handle) current.handle = story.handle;
+  }
+
+  return [...grouped.values()].sort((a, b) => b.count - a.count || b.latest.localeCompare(a.latest));
+}
+
+async function getContributors(): Promise<GitHubContributor[]> {
+  try {
+    const response = await fetch(`https://api.github.com/repos/${site.githubRepo}/contributors?per_page=24`, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        "User-Agent": "UseGrokBot-community-page",
+      },
+      next: { revalidate: 3600 },
+    });
+    if (!response.ok) return [];
+    const rows = (await response.json()) as Array<{
+      login?: string;
+      contributions?: number;
+      html_url?: string;
+      type?: string;
+    }>;
+    return rows
+      .filter(
+        (item) =>
+          item.type === "User" &&
+          item.login &&
+          item.html_url &&
+          !item.login.toLowerCase().includes("[bot]") &&
+          !item.login.toLowerCase().endsWith("-bot"),
+      )
+      .slice(0, 16)
+      .map((item) => ({
+        login: item.login!,
+        contributions: item.contributions ?? 0,
+        htmlUrl: item.html_url!,
+      }));
+  } catch {
+    return [];
+  }
+}

--- a/app/[locale]/not-found.tsx
+++ b/app/[locale]/not-found.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { BlobatarAvatar } from "@/components/BlobatarAvatar";
 import { LocaleLink } from "@/components/LocaleLink";
 import { useI18n } from "@/lib/i18n";
 
@@ -8,6 +9,7 @@ export default function NotFound() {
 
   return (
     <div className="mx-auto max-w-[640px] px-5 py-24 text-center">
+      <BlobatarAvatar name="usegrokbot-lost-bot" size={104} expression="sad" className="mx-auto mb-6" />
       <h1 className="text-3xl font-medium tracking-tight text-ink">{t("pages.notFoundTitle")}</h1>
       <p className="mt-3 text-mute">{t("pages.notFoundBody")}</p>
       <LocaleLink

--- a/app/[locale]/submit/page.tsx
+++ b/app/[locale]/submit/page.tsx
@@ -192,14 +192,14 @@ export default function SubmitPage() {
 }
 
 function identityCopy(locale: string) {
-  if (locale === "zh-hk") {
+  if (locale === "zh-Hant") {
     return {
       title: "你嘅 UseGrokBot 身份",
       body: "貼上 X URL，就會即時生成你嘅社群 Blob。同一個 handle 永遠係同一隻。",
       placeholderName: "你嘅 Grok Bot",
     };
   }
-  if (locale === "zh-cn") {
+  if (locale === "zh-Hans") {
     return {
       title: "你的 UseGrokBot 身份",
       body: "贴上 X URL，就会即时生成你的社区 Blob。同一个 handle 永远是同一只。",

--- a/app/[locale]/submit/page.tsx
+++ b/app/[locale]/submit/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { BlobatarAvatar } from "@/components/BlobatarAvatar";
 import { LocaleLink } from "@/components/LocaleLink";
 import { useI18n } from "@/lib/i18n";
 import { site } from "@/lib/site";
@@ -14,6 +15,16 @@ function isPublicXUrl(value: string) {
   }
 }
 
+function identityFromXUrl(value: string) {
+  try {
+    const url = new URL(value.trim());
+    if (!/^(www\.)?(x\.com|twitter\.com)$/i.test(url.hostname)) return "";
+    return decodeURIComponent(url.pathname.split("/").filter(Boolean)[0] ?? "").replace(/^@/, "");
+  } catch {
+    return "";
+  }
+}
+
 type IngestResponse = {
   status: "published" | "queued" | "extracted" | "skipped";
   slug?: string;
@@ -24,10 +35,14 @@ type IngestResponse = {
 };
 
 export default function SubmitPage() {
-  const { t } = useI18n();
+  const { t, locale } = useI18n();
   const [error, setError] = useState("");
   const [sending, setSending] = useState(false);
   const [done, setDone] = useState<IngestResponse | null>(null);
+  const [xUrlPreview, setXUrlPreview] = useState("");
+  const handle = identityFromXUrl(xUrlPreview);
+  const identitySeed = handle || "your-grok-bot";
+  const copy = identityCopy(locale);
 
   async function onSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -93,9 +108,15 @@ export default function SubmitPage() {
 
       {done ? (
         <div className="mt-10 rounded-2xl border border-line bg-elevated px-5 py-8">
-          <p className="text-lg font-medium text-ink">
-            {done.status === "published" ? t("submit.published") : t("submit.queued")}
-          </p>
+          <div className="flex items-center gap-4">
+            <BlobatarAvatar name={identitySeed} size={56} expression="love" />
+            <div>
+              <p className="text-lg font-medium text-ink">
+                {done.status === "published" ? t("submit.published") : t("submit.queued")}
+              </p>
+              {handle ? <p className="mt-1 text-[13px] text-faint">@{handle}</p> : null}
+            </div>
+          </div>
           <div className="mt-5 flex flex-wrap gap-3">
             {done.url ? (
               <LocaleLink href={done.url} className="accent-gradient inline-flex h-11 items-center rounded-[10px] px-4 text-sm font-medium">
@@ -116,7 +137,29 @@ export default function SubmitPage() {
         </div>
       ) : (
         <form onSubmit={onSubmit} className="mt-10 space-y-5">
-          <Field name="xUrl" label={t("submit.xUrl")} required placeholder="https://x.com/..." />
+          <label className="block">
+            <span className="mb-1.5 block text-[12px] font-medium text-faint">{t("submit.xUrl")}</span>
+            <input
+              name="xUrl"
+              required
+              placeholder="https://x.com/..."
+              value={xUrlPreview}
+              onChange={(event) => setXUrlPreview(event.target.value)}
+              className="h-11 w-full rounded-[10px] border border-line bg-input px-3 text-sm text-ink placeholder:text-faint"
+            />
+          </label>
+
+          <div className="flex items-center gap-4 rounded-2xl border border-line bg-elevated px-4 py-4">
+            <BlobatarAvatar name={identitySeed} size={72} expression={handle ? "happy" : "thinking"} />
+            <div className="min-w-0">
+              <p className="text-sm font-medium text-ink">{copy.title}</p>
+              <p className="mt-1 truncate text-[13px] text-mute">
+                {handle ? `@${handle}` : copy.placeholderName}
+              </p>
+              <p className="mt-1 text-[12px] leading-5 text-faint">{copy.body}</p>
+            </div>
+          </div>
+
           <label className="block">
             <span className="mb-1.5 block text-[12px] font-medium text-faint">{t("submit.prompt")}</span>
             <textarea
@@ -148,26 +191,24 @@ export default function SubmitPage() {
   );
 }
 
-function Field({
-  name,
-  label,
-  required,
-  placeholder,
-}: {
-  name: string;
-  label: string;
-  required?: boolean;
-  placeholder?: string;
-}) {
-  return (
-    <label className="block">
-      <span className="mb-1.5 block text-[12px] font-medium text-faint">{label}</span>
-      <input
-        name={name}
-        required={required}
-        placeholder={placeholder}
-        className="h-11 w-full rounded-[10px] border border-line bg-input px-3 text-sm text-ink placeholder:text-faint"
-      />
-    </label>
-  );
+function identityCopy(locale: string) {
+  if (locale === "zh-hk") {
+    return {
+      title: "你嘅 UseGrokBot 身份",
+      body: "貼上 X URL，就會即時生成你嘅社群 Blob。同一個 handle 永遠係同一隻。",
+      placeholderName: "你嘅 Grok Bot",
+    };
+  }
+  if (locale === "zh-cn") {
+    return {
+      title: "你的 UseGrokBot 身份",
+      body: "贴上 X URL，就会即时生成你的社区 Blob。同一个 handle 永远是同一只。",
+      placeholderName: "你的 Grok Bot",
+    };
+  }
+  return {
+    title: "Your UseGrokBot identity",
+    body: "Paste an X URL to reveal your community Blob. Same handle, same creature every time.",
+    placeholderName: "Your Grok Bot",
+  };
 }

--- a/app/global-not-found.tsx
+++ b/app/global-not-found.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import Link from "next/link";
+import { BlobatarAvatar } from "@/components/BlobatarAvatar";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -27,6 +28,7 @@ export default function GlobalNotFound() {
     >
       <body className="flex min-h-full flex-col bg-canvas font-sans text-ink antialiased">
         <div className="mx-auto max-w-[640px] px-5 py-24 text-center">
+          <BlobatarAvatar name="usegrokbot-lost-bot" size={104} expression="sad" className="mx-auto mb-6" />
           <h1 className="text-3xl font-medium tracking-tight text-ink">Page not found</h1>
           <p className="mt-3 text-mute">That URL is not in the library.</p>
           <Link

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -30,6 +30,11 @@ export default function sitemap(): MetadataRoute.Sitemap {
     (latest, item) => (item.publishedAt > latest ? item.publishedAt : latest),
     discoverStories[0]?.publishedAt ?? LAST_REVIEWED,
   );
+  const communityHandles = [...new Set(
+    discoverStories
+      .filter((item) => item.source === "community" && item.handle)
+      .map((item) => item.handle!.toLowerCase()),
+  )];
 
   return [
     ...entries("/", { changeFrequency: "weekly", priority: 1 }, day(latestStory)),
@@ -40,6 +45,10 @@ export default function sitemap(): MetadataRoute.Sitemap {
     ...entries("/use-cases", { changeFrequency: "weekly", priority: 0.8 }, reviewed),
     ...entries("/categories", { changeFrequency: "weekly", priority: 0.8 }, reviewed),
     ...entries("/integrations", { changeFrequency: "weekly", priority: 0.8 }, reviewed),
+    ...entries("/community", { changeFrequency: "weekly", priority: 0.6 }, day(latestStory)),
+    ...communityHandles.flatMap((handle) =>
+      entries(`/community/${handle}`, { changeFrequency: "weekly", priority: 0.5 }, day(latestStory)),
+    ),
     ...entries("/prompts", { changeFrequency: "weekly", priority: 0.8 }, reviewed),
     ...entries("/learn", { changeFrequency: "weekly", priority: 0.8 }, reviewed),
     ...entries("/submit", { changeFrequency: "monthly", priority: 0.5 }, reviewed),

--- a/components/AuthorAvatar.tsx
+++ b/components/AuthorAvatar.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { cn } from "@/lib/cn";
+import { BlobatarAvatar } from "./BlobatarAvatar";
 
 export function AuthorAvatar({
   name,
@@ -15,13 +16,6 @@ export function AuthorAvatar({
   className?: string;
 }) {
   const [failed, setFailed] = useState(false);
-  const initials = name
-    .split(/\s+/)
-    .filter(Boolean)
-    .map((part) => part[0])
-    .join("")
-    .slice(0, 2)
-    .toUpperCase();
   const src = handle && !failed ? `https://unavatar.io/x/${encodeURIComponent(handle)}` : undefined;
   const box = size === 48 ? "size-12" : "size-10";
 
@@ -40,15 +34,12 @@ export function AuthorAvatar({
   }
 
   return (
-    <span
-      aria-hidden
-      className={cn(
-        box,
-        "inline-flex shrink-0 items-center justify-center rounded-full bg-elevated text-[11px] font-medium text-mute",
-        className,
-      )}
-    >
-      {initials}
-    </span>
+    <BlobatarAvatar
+      name={handle ?? name}
+      size={size}
+      expression="happy"
+      className={className}
+      title={`${name} community avatar`}
+    />
   );
 }

--- a/components/BlobatarAvatar.tsx
+++ b/components/BlobatarAvatar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { cn } from "@/lib/cn";
 
 const BLOBATAR_ORIGIN = "https://blobatar.dev/avatar";
@@ -20,21 +20,50 @@ export function BlobatarAvatar({
   className?: string;
   title?: string;
 }) {
+  const [failed, setFailed] = useState(false);
   const safeName = name.trim() || "usegrokbot-community";
+  const initials = useMemo(
+    () =>
+      safeName
+        .replace(/^@/, "")
+        .split(/[\s._-]+/)
+        .filter(Boolean)
+        .map((part) => part[0])
+        .join("")
+        .slice(0, 2)
+        .toUpperCase() || "UG",
+    [safeName],
+  );
   const idleSrc = useMemo(() => blobatarUrl(safeName, size), [safeName, size]);
   const hoverSrc = useMemo(() => blobatarUrl(safeName, size, expression), [safeName, size, expression]);
+
+  if (failed) {
+    return (
+      <span
+        aria-hidden={title ? undefined : true}
+        title={title}
+        className={cn(
+          "inline-flex shrink-0 items-center justify-center rounded-full bg-elevated text-[11px] font-medium text-mute",
+          className,
+        )}
+        style={{ width: size, height: size }}
+      >
+        {initials}
+      </span>
+    );
+  }
 
   return (
     <span
       className={cn(
-        "blobatar group/blobatar relative inline-flex shrink-0 overflow-hidden rounded-full bg-elevated",
+        "blobatar group/blobatar relative inline-flex shrink-0 overflow-hidden rounded-full bg-elevated motion-safe:transition-transform motion-safe:duration-200 motion-safe:hover:-translate-y-0.5 motion-safe:hover:rotate-2",
         className,
       )}
       style={{ width: size, height: size }}
       title={title}
       aria-hidden={title ? undefined : true}
     >
-      {/* Blobatar's public HTTP endpoint is used as a lightweight deterministic avatar source. */}
+      {/* Blobatar's public HTTP endpoint keeps avatars deterministic without adding a client bundle dependency. */}
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img
         src={idleSrc}
@@ -42,6 +71,7 @@ export function BlobatarAvatar({
         width={size}
         height={size}
         className="absolute inset-0 size-full object-cover transition-opacity duration-150 group-hover/blobatar:opacity-0"
+        onError={() => setFailed(true)}
       />
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img

--- a/components/CommunityView.tsx
+++ b/components/CommunityView.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { BlobatarAvatar } from "@/components/BlobatarAvatar";
+import { LocaleLink } from "@/components/LocaleLink";
+import { useI18n } from "@/lib/i18n";
+
+export type CommunityIdentity = {
+  name: string;
+  handle?: string;
+  count: number;
+  latest: string;
+};
+
+export type GitHubContributor = {
+  login: string;
+  contributions: number;
+  htmlUrl: string;
+};
+
+export function CommunityView({
+  identities,
+  contributors,
+}: {
+  identities: CommunityIdentity[];
+  contributors: GitHubContributor[];
+}) {
+  const { locale } = useI18n();
+  const copy = communityCopy(locale);
+
+  return (
+    <div className="mx-auto max-w-[1120px] px-5 py-12 md:px-8 md:py-16">
+      <div className="max-w-[760px]">
+        <h1 className="text-[clamp(30px,5vw,48px)] font-medium tracking-tight text-ink">{copy.title}</h1>
+        <p className="mt-4 text-base leading-7 text-mute">{copy.body}</p>
+        <LocaleLink
+          href="/submit"
+          className="accent-gradient mt-6 inline-flex h-11 items-center rounded-[10px] px-5 text-sm font-medium text-inverse"
+        >
+          {copy.submit} →
+        </LocaleLink>
+      </div>
+
+      <section className="mt-14">
+        <div className="flex items-end justify-between gap-4">
+          <div>
+            <h2 className="text-[24px] font-medium tracking-tight text-ink">{copy.builders}</h2>
+            <p className="mt-2 text-sm text-mute">{copy.buildersBody}</p>
+          </div>
+          <a
+            href="https://github.com/a70win-wq/usegrokbot/graphs/contributors"
+            target="_blank"
+            rel="noreferrer"
+            className="hidden text-[13px] text-mute hover:text-ink sm:inline"
+          >
+            {copy.github} ↗
+          </a>
+        </div>
+
+        {contributors.length ? (
+          <div className="mt-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            {contributors.map((person) => (
+              <a
+                key={person.login}
+                href={person.htmlUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="group flex items-center gap-3 rounded-2xl border border-line bg-card px-4 py-4 transition hover:border-line-strong"
+              >
+                <BlobatarAvatar name={`github:${person.login}`} size={56} expression="smug" />
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-medium text-ink">@{person.login}</p>
+                  <p className="mt-1 text-[12px] text-faint">
+                    {person.contributions} {copy.contributions}
+                  </p>
+                </div>
+              </a>
+            ))}
+          </div>
+        ) : (
+          <div className="mt-6 rounded-2xl border border-line bg-elevated px-5 py-6 text-sm text-mute">
+            {copy.buildersFallback}
+          </div>
+        )}
+      </section>
+
+      <section className="mt-16">
+        <h2 className="text-[24px] font-medium tracking-tight text-ink">{copy.zoo}</h2>
+        <p className="mt-2 max-w-2xl text-sm leading-6 text-mute">{copy.zooBody}</p>
+
+        <div className="mt-6 grid gap-3 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4">
+          {identities.map((person) => {
+            const body = (
+              <>
+                <BlobatarAvatar name={person.handle ?? person.name} size={56} expression="happy" />
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-medium text-ink">{person.name}</p>
+                  <p className="mt-0.5 truncate text-[12px] text-faint">
+                    {person.handle ? `@${person.handle}` : copy.sourceOnly}
+                  </p>
+                  <p className="mt-1 text-[12px] text-mute">
+                    {person.count} {person.count === 1 ? copy.case : copy.cases}
+                  </p>
+                </div>
+              </>
+            );
+
+            return person.handle ? (
+              <LocaleLink
+                key={person.handle}
+                href={`/community/${encodeURIComponent(person.handle.toLowerCase())}`}
+                className="group flex items-center gap-3 rounded-2xl border border-line bg-card px-4 py-4 transition hover:border-line-strong"
+              >
+                {body}
+              </LocaleLink>
+            ) : (
+              <div
+                key={`${person.name}-${person.latest}`}
+                className="flex items-center gap-3 rounded-2xl border border-line bg-card px-4 py-4"
+              >
+                {body}
+              </div>
+            );
+          })}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function communityCopy(locale: string) {
+  if (locale === "zh-hk") {
+    return {
+      title: "UseGrokBot 社群",
+      body: "睇下邊啲人分享緊真實 Grok Bot 案例，同埋邊啲開源 Contributor 幫緊 UseGrokBot 成長。每個公開 handle 都有一隻固定 Blob 身份。",
+      submit: "加入你嘅 Grok Bot",
+      builders: "Community Builders",
+      buildersBody: "幫手改善 UseGrokBot 嘅開源 Contributor。",
+      github: "喺 GitHub 睇",
+      contributions: "次 contributions",
+      buildersFallback: "Contributor 資料暫時未載入，但 GitHub repo 仍然可以正常瀏覽。",
+      zoo: "Blob 動物園",
+      zooBody: "同一個 handle 永遠生成同一隻 Blob。呢啲係社群身份，唔係真人頭像。",
+      case: "個案例",
+      cases: "個案例",
+      sourceOnly: "公開來源作者",
+    };
+  }
+  if (locale === "zh-cn") {
+    return {
+      title: "UseGrokBot 社区",
+      body: "看看谁在分享真实 Grok Bot 案例，以及哪些开源 Contributor 正在帮助 UseGrokBot 成长。每个公开 handle 都有一只固定 Blob 身份。",
+      submit: "加入你的 Grok Bot",
+      builders: "Community Builders",
+      buildersBody: "帮助改善 UseGrokBot 的开源 Contributor。",
+      github: "在 GitHub 查看",
+      contributions: "次 contributions",
+      buildersFallback: "Contributor 数据暂时未载入，但 GitHub repo 仍然可以正常浏览。",
+      zoo: "Blob 动物园",
+      zooBody: "同一个 handle 永远生成同一只 Blob。这些是社区身份，不是真人头像。",
+      case: "个案例",
+      cases: "个案例",
+      sourceOnly: "公开来源作者",
+    };
+  }
+  return {
+    title: "UseGrokBot Community",
+    body: "Meet the people behind real Grok Bot examples — plus the open-source builders improving UseGrokBot. Every public handle also gets one stable community Blob.",
+    submit: "Add your Grok Bot",
+    builders: "Community Builders",
+    buildersBody: "Open-source contributors helping the project grow.",
+    github: "View on GitHub",
+    contributions: "contributions",
+    buildersFallback: "Contributor data is temporarily unavailable, but the GitHub repository is still public.",
+    zoo: "The Blob Zoo",
+    zooBody: "The same handle always generates the same Blob. These are community identities, not replacements for real author photos.",
+    case: "case",
+    cases: "cases",
+    sourceOnly: "public source author",
+  };
+}

--- a/components/CommunityView.tsx
+++ b/components/CommunityView.tsx
@@ -128,7 +128,7 @@ export function CommunityView({
 }
 
 function communityCopy(locale: string) {
-  if (locale === "zh-hk") {
+  if (locale === "zh-Hant") {
     return {
       title: "UseGrokBot 社群",
       body: "睇下邊啲人分享緊真實 Grok Bot 案例，同埋邊啲開源 Contributor 幫緊 UseGrokBot 成長。每個公開 handle 都有一隻固定 Blob 身份。",
@@ -145,7 +145,7 @@ function communityCopy(locale: string) {
       sourceOnly: "公開來源作者",
     };
   }
-  if (locale === "zh-cn") {
+  if (locale === "zh-Hans") {
     return {
       title: "UseGrokBot 社区",
       body: "看看谁在分享真实 Grok Bot 案例，以及哪些开源 Contributor 正在帮助 UseGrokBot 成长。每个公开 handle 都有一只固定 Blob 身份。",

--- a/components/DiscoverFeed.tsx
+++ b/components/DiscoverFeed.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { BlobatarAvatar } from "@/components/BlobatarAvatar";
 import { DiscoverCard } from "@/components/DiscoverCard";
 import { LocaleLink } from "@/components/LocaleLink";
 import { NamedIcon } from "@/components/icons";
@@ -268,6 +269,12 @@ export function DiscoverFeed({
 
       {stories.length === 0 ? (
         <div className="mt-8 rounded-2xl border border-line bg-elevated px-5 py-10 text-center">
+          <BlobatarAvatar
+            name={`empty:${query || tab}:${category}:${outcome}:${app}`}
+            size={72}
+            expression="thinking"
+            className="mx-auto mb-4"
+          />
           <p className="text-sm text-ink">
             {tab === "tested" ? t("discover.testedEmpty") : t("discover.empty")}
           </p>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -7,7 +7,8 @@ import { GitHubStar } from "./GitHubStar";
 import { LocaleLink } from "./LocaleLink";
 
 export function Footer({ stars }: { stars?: number | null }) {
-  const { t } = useI18n();
+  const { t, locale } = useI18n();
+  const communityLabel = locale === "zh-hk" ? "社群" : locale === "zh-cn" ? "社区" : "Community";
 
   return (
     <footer className="mt-auto border-t border-line">
@@ -29,6 +30,9 @@ export function Footer({ stars }: { stars?: number | null }) {
           <LocaleLink href="/integrations" className="hover:text-ink">
             {t("nav.integrations")}
           </LocaleLink>
+          <LocaleLink href="/community" className="hover:text-ink">
+            {communityLabel}
+          </LocaleLink>
           <LocaleLink href="/prompts" className="hover:text-ink">
             {t("nav.prompts")}
           </LocaleLink>
@@ -41,11 +45,14 @@ export function Footer({ stars }: { stars?: number | null }) {
           <GetGrokBot variant="link" />
           <GitHubStar stars={stars} label="always" />
         </div>
-        <p className="mt-6 text-[12px] text-faint">
+        <div className="mt-6 flex flex-wrap gap-x-4 gap-y-2 text-[12px] text-faint">
           <a href="https://github.com/jeremy-prt/bloub" className="hover:text-mute" rel="noreferrer">
             {t("bot.credit")}
           </a>
-        </p>
+          <a href="https://github.com/Alain00/blobatar" className="hover:text-mute" rel="noreferrer">
+            Community blobs powered by Blobatar
+          </a>
+        </div>
       </div>
     </footer>
   );

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -8,7 +8,7 @@ import { LocaleLink } from "./LocaleLink";
 
 export function Footer({ stars }: { stars?: number | null }) {
   const { t, locale } = useI18n();
-  const communityLabel = locale === "zh-hk" ? "社群" : locale === "zh-cn" ? "社区" : "Community";
+  const communityLabel = locale === "zh-Hant" ? "社群" : locale === "zh-Hans" ? "社区" : "Community";
 
   return (
     <footer className="mt-auto border-t border-line">

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -21,7 +21,7 @@ export function Header({ stars }: { stars?: number | null }) {
   const { slugs } = useSaved();
   const { t, locale } = useI18n();
   const [open, setOpen] = useState(false);
-  const communityLabel = locale === "zh-hk" ? "社群" : locale === "zh-cn" ? "社区" : "Community";
+  const communityLabel = locale === "zh-Hant" ? "社群" : locale === "zh-Hans" ? "社区" : "Community";
 
   const nav = [
     {

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -19,8 +19,9 @@ export function Header({ stars }: { stars?: number | null }) {
   const pathname = usePathname();
   const path = stripLocalePrefix(pathname);
   const { slugs } = useSaved();
-  const { t } = useI18n();
+  const { t, locale } = useI18n();
   const [open, setOpen] = useState(false);
+  const communityLabel = locale === "zh-hk" ? "社群" : locale === "zh-cn" ? "社区" : "Community";
 
   const nav = [
     {
@@ -34,6 +35,7 @@ export function Header({ stars }: { stars?: number | null }) {
       label: t("nav.integrations"),
       match: (current: string) => current.startsWith("/integrations") || current.startsWith("/apps"),
     },
+    { href: "/community", label: communityLabel },
     { href: "/submit", label: t("nav.submitShort") },
     { href: "/learn/what-is-grok-bot", label: t("nav.about"), match: (current: string) => current.startsWith("/learn") },
   ];


### PR DESCRIPTION
Adds the full playful community identity layer without replacing real author attribution.

## Included
- real X avatars stay first; Blobatar is the fallback
- hover expressions for Blob identities
- live Blob identity preview on Submit
- playful Blob empty-search state
- Blob 404 states
- `/community` with Community Builders + Blob Zoo
- `/community/[handle]` profiles grouping each author’s public cases
- Community navigation + sitemap entries
- subtle Blobatar credit in footer

## Design rule
Blob identities are a playful community layer only. Real author photos, handles, original source links, and trust labels remain authoritative.

## Resilience
Uses Blobatar’s deterministic HTTP endpoint with an initials fallback if the endpoint is unavailable. No new npm dependency or client bundle package is added.