### PR TITLE
Add Gergely Orosz support-inbox Stripe refunds Discover story

### DIFF
--- a/data/discover.ts
+++ b/data/discover.ts
@@ -90,6 +90,7 @@ const ALEX_FINN_LOOPS = "https://x.com/AlexFinn/status/2089038594690408891";
 const ALEX_FINN_WALKTHROUGH = "https://x.com/AlexFinn/status/2089505950470459659";
 const MARIO_3D_GAME = "https://x.com/RoundtableSpace/status/2090117840091419126";
 const KUN_FIRSTMATE = "https://x.com/kunchenguid/status/2089792928092963234";
+const GERGELY_REFUNDS = "https://x.com/GergelyOrosz/status/2090085668768694562";
 const YUNTA_CALENDAR = "https://x.com/yunta_tsai/status/2087415205756391461";
 const YUNTA_MATH = "https://x.com/yunta_tsai/status/2088832993108590853";
 const YUNTA_PARENTS = "https://x.com/yunta_tsai/status/2089927285113803053";
@@ -231,6 +232,43 @@ const curatedStories: DiscoverStory[] = [
     sourceLabel: "Rahul on X",
     trending: true,
     featured: true,
+  },
+  {
+    slug: "support-refunds-gergely-orosz",
+    title: "Support Inbox, Then Refund",
+    headline:
+      "Gergely Orosz hooked Grok Bot to his customer-support inbox — and connected Stripe for routine refunds",
+    whatTheyDid:
+      "On 19 Aug 2026 Gergely Orosz (@GergelyOrosz) wrote that he hooked Grok Bot to his customer-support emails. The Bot can connect to Stripe via API for agentic operations — routine refunds as the example. The attached screenshot is Stripe’s agent auth screen: “Agent is now authorised to continue.”",
+    howItWorks:
+      "Support mail in, Stripe API out. He is impressed Stripe already built the agentic flow. We keep Gergely’s permalink. We did not re-run his inbox or issue a refund.",
+    whyUseful:
+      "Support plus refunds is the job people actually run a shop for. This is a named person showing the Bot in the live inbox and the payment API, not a generic “try agents” thread.",
+    whyItMatters:
+      "Same-day community case: a real support inbox, a real Stripe authorize screen. Community; we did not mark it tested.",
+    whoShouldTry: [
+      "Founders doing their own support",
+      "Ops who already refund in Stripe",
+      "Anyone whose support queue is also the billing queue",
+    ],
+    usefulFor: "Support / Operations",
+    quote:
+      "Hooked up Grok Bot to my customer support emails... and it can connect to Stripe, via API, for agentic operations, e.g. routine refunds.",
+    result: "Support inbox · Stripe API refunds",
+    category: "operations",
+    outcomes: ["automate-work", "save-time"],
+    apps: ["gmail", "browser"],
+    difficulty: "medium",
+    schedule: "always-on",
+    source: "community",
+    authorName: "Gergely Orosz",
+    handle: "GergelyOrosz",
+    publishedAt: "2026-08-19",
+    xPostUrl: GERGELY_REFUNDS,
+    sourceUrl: GERGELY_REFUNDS,
+    sourceLabel: "Gergely Orosz on X",
+    relatedUseCase: "support-email-assistant",
+    trending: true,
   },
   {
     slug: "calendar-booking-yunta-tsai",

--- a/lib/i18n/discover.ts
+++ b/lib/i18n/discover.ts
@@ -456,6 +456,22 @@ const hant: Record<string, DiscoverStoryI18n> = {
       "hit + in the chat and record yourself doing it in the browser. the bot watches, then it can do it again.",
     result: "錄一次 · Bot 再行同一條路",
   },
+  "support-refunds-gergely-orosz": {
+    title: "客服收件箱，再退款",
+    headline: "Gergely Orosz 把 Grok Bot 駁去客服電郵——再經 Stripe API 做例行退款",
+    whatTheyDid:
+      "2026 年 8 月 19 日，Gergely Orosz（@GergelyOrosz）寫他把 Grok Bot 駁去自己的客服電郵。Bot 可以經 API 連 Stripe，做 agentic 操作——例子是例行退款。附件截圖是 Stripe 的 agent 授權畫面：「Agent is now authorised to continue。」",
+    howItWorks:
+      "客服郵件入、Stripe API 出。他讚 Stripe 已經砌好呢條 agentic 流程。我們保留 Gergely 原帖。沒有重跑他的收件箱，也沒有代發退款。",
+    whyUseful:
+      "客服加退款就是開店的人實際在做的工。這是具名的人，把 Bot 放進真正的收件箱同付款 API，不是空泛「試試 agent」。",
+    whyItMatters: "即日社群例子：真正的客服收件箱，真正的 Stripe 授權畫面。社群；沒有標已測試。",
+    whoShouldTry: ["自己兼客服的創辦人", "已經在 Stripe 退款的營運", "客服隊列同時是帳務隊列的人"],
+    usefulFor: "支援 / 營運",
+    quote:
+      "Hooked up Grok Bot to my customer support emails... and it can connect to Stripe, via API, for agentic operations, e.g. routine refunds.",
+    result: "客服收件箱 · Stripe API 退款",
+  },
 };
 
 const hans: Record<string, DiscoverStoryI18n> = {
@@ -898,6 +914,22 @@ const hans: Record<string, DiscoverStoryI18n> = {
     quote:
       "hit + in the chat and record yourself doing it in the browser. the bot watches, then it can do it again.",
     result: "录一次 · Bot 再走同一条路",
+  },
+  "support-refunds-gergely-orosz": {
+    title: "客服收件箱，再退款",
+    headline: "Gergely Orosz 把 Grok Bot 接到客服邮件——再经 Stripe API 做例行退款",
+    whatTheyDid:
+      "2026 年 8 月 19 日，Gergely Orosz（@GergelyOrosz）写他把 Grok Bot 接到自己的客服邮件。Bot 可以经 API 连 Stripe，做 agentic 操作——例子是例行退款。附件截图是 Stripe 的 agent 授权画面：「Agent is now authorised to continue。」",
+    howItWorks:
+      "客服邮件入、Stripe API 出。他赞 Stripe 已经砌好这条 agentic 流程。我们保留 Gergely 原帖。没有重跑他的收件箱，也没有代发退款。",
+    whyUseful:
+      "客服加退款就是开店的人实际在做的工。这是具名的人，把 Bot 放进真正的收件箱和付款 API，不是空泛「试试 agent」。",
+    whyItMatters: "当日社区例子：真正的客服收件箱，真正的 Stripe 授权画面。社区；没有标已测试。",
+    whoShouldTry: ["自己兼客服的创始人", "已经在 Stripe 退款的运营", "客服队列同时也是账务队列的人"],
+    usefulFor: "支持 / 运营",
+    quote:
+      "Hooked up Grok Bot to my customer support emails... and it can connect to Stripe, via API, for agentic operations, e.g. routine refunds.",
+    result: "客服收件箱 · Stripe API 退款",
   },
 };
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds one live-verified Grok Bot Discover story from 19 Aug 2026:

- **Gergely Orosz** (`@GergelyOrosz`) — hooked Grok Bot to his customer-support email inbox; Bot connects to Stripe via API for agentic operations such as routine refunds. Attached screenshot is Stripe’s agent auth screen: “Agent is now authorised to continue.”
- Slug: `support-refunds-gergely-orosz`
- Community, operations, trending, **not featured** (Elon / Nate / Rahul / Yun-Ta stay featured)
- Not marked tested
- Result describes the job only — no invented dollar amounts
- zh-Hant / zh-Hans copy in `lib/i18n/discover.ts`

Permalink: https://x.com/GergelyOrosz/status/2090085668768694562

## Why

Same-day public case of a real support inbox plus a payment API. Official `@bot` quote permalink was not found at write time, so the card stays on Gergely’s original post.

**Skipped:** Codez `@0xCodez` https://x.com/0xCodez/status/2089715168565448761 — fetched live; that permalink is a Jimmy Ba talk clip pointing at an article, not the 10-step how-to itself.

## Checks

- [x] No invented X authors, handles, tweet IDs, or result numbers
- [x] Community stories link back to the original source
- [x] Tested is only used after UseGrokBot actually ran the Bot
- [x] Translations keep the same message keys
- [x] `npx tsx scripts/validate-discover.ts` — ok (47 stories)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4243cfd0-c8f5-4f73-b2d3-b7e255d578cf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4243cfd0-c8f5-4f73-b2d3-b7e255d578cf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

