### PR TITLE
Add Sawyer Merritt remote lawn-mower Discover story

### DIFF
--- a/data/discover.ts
+++ b/data/discover.ts
@@ -91,6 +91,7 @@ const ALEX_FINN_WALKTHROUGH = "https://x.com/AlexFinn/status/2089505950470459659
 const MARIO_3D_GAME = "https://x.com/RoundtableSpace/status/2090117840091419126";
 const KUN_FIRSTMATE = "https://x.com/kunchenguid/status/2089792928092963234";
 const GERGELY_REFUNDS = "https://x.com/GergelyOrosz/status/2090085668768694562";
+const SAWYER_MOWER = "https://x.com/SawyerMerritt/status/2090179852171174211";
 const YUNTA_CALENDAR = "https://x.com/yunta_tsai/status/2087415205756391461";
 const YUNTA_MATH = "https://x.com/yunta_tsai/status/2088832993108590853";
 const YUNTA_PARENTS = "https://x.com/yunta_tsai/status/2089927285113803053";
@@ -268,6 +269,41 @@ const curatedStories: DiscoverStory[] = [
     sourceUrl: GERGELY_REFUNDS,
     sourceLabel: "Gergely Orosz on X",
     relatedUseCase: "support-email-assistant",
+    trending: true,
+  },
+  {
+    slug: "remote-mower-sawyer-merritt",
+    title: "Remote the Lawn Mower",
+    headline:
+      "Sawyer Merritt set up Grok Bot to remotely control his autonomous robot lawn mower — 50 miles away",
+    whatTheyDid:
+      "On 19 Aug 2026 Sawyer Merritt (@SawyerMerritt) wrote that he set up Grok Bot to remotely control his autonomous robot lawn mower 50 miles away. Setup took two minutes. He told it to start mowing; it started three seconds later. Then he had it dock itself. He says he will set up his vacuum next, and have a Grok Bot dedicated to controlling and managing all of his autonomous robots. The attached screenshot is an Engineer Bot chat: linked to a Navimow X450, then “Start mowing now” and “Go dock.” The clip is the Navimow X450 map.",
+    howItWorks:
+      "Chat in, mower out. We keep Sawyer’s permalink. We did not re-run the mower or the dock.",
+    whyUseful:
+      "Remote start and dock is the job people get: not a chat summary — a machine 50 miles away, told to mow, then sent home.",
+    whyItMatters:
+      "Same-day community case: a named person, a live mower, an Engineer Bot screenshot. Community; we did not mark it tested.",
+    whoShouldTry: [
+      "Anyone with a robot mower",
+      "People who leave home and still need the yard done",
+      "Anyone collecting household robots under one Bot",
+    ],
+    usefulFor: "Personal / Household",
+    quote: "I told it to start mowing and it started 3 seconds later. Then I had it dock itself.",
+    result: "Remote mower start · dock",
+    category: "personal",
+    outcomes: ["save-time", "automate-work"],
+    apps: ["browser"],
+    difficulty: "easy",
+    schedule: "one-time",
+    source: "community",
+    authorName: "Sawyer Merritt",
+    handle: "SawyerMerritt",
+    publishedAt: "2026-08-19",
+    xPostUrl: SAWYER_MOWER,
+    sourceUrl: SAWYER_MOWER,
+    sourceLabel: "Sawyer Merritt on X",
     trending: true,
   },
   {

--- a/lib/i18n/discover.ts
+++ b/lib/i18n/discover.ts
@@ -472,6 +472,19 @@ const hant: Record<string, DiscoverStoryI18n> = {
       "Hooked up Grok Bot to my customer support emails... and it can connect to Stripe, via API, for agentic operations, e.g. routine refunds.",
     result: "客服收件箱 · Stripe API 退款",
   },
+  "remote-mower-sawyer-merritt": {
+    title: "遠程開割草機",
+    headline: "Sawyer Merritt 設定 Grok Bot，遠程控制五十哩外的自動割草機械人",
+    whatTheyDid:
+      "2026 年 8 月 19 日，Sawyer Merritt（@SawyerMerritt）寫他把 Grok Bot 設成可以遠程控制五十哩外的自動割草機械人。設定用了兩分鐘。他叫它開始割草，三秒後就動了。然後叫它自己回充電座。他話下一步會駁吸塵機，再專用一隻 Grok Bot 管所有自動機械人。附件截圖是 Engineer Bot 對話：已連 Navimow X450，再「Start mowing now」同「Go dock」。片段是 Navimow X450 地圖。",
+    howItWorks: "聊天入、割草機出。我們保留 Sawyer 原帖。沒有重跑那次開割或回座。",
+    whyUseful: "遠程開同回座就是人人都明的工：不是聊天摘要——係五十哩外的機器，叫它割，再叫它回家。",
+    whyItMatters: "即日社群例子：具名的人、在用的割草機、Engineer Bot 截圖。社群；沒有標已測試。",
+    whoShouldTry: ["有割草機械人的人", "出門了但草地仲要割的人", "想用一隻 Bot 管家用機械人的人"],
+    usefulFor: "個人 / 家庭",
+    quote: "I told it to start mowing and it started 3 seconds later. Then I had it dock itself.",
+    result: "遠程開割草 · 回座",
+  },
 };
 
 const hans: Record<string, DiscoverStoryI18n> = {
@@ -930,6 +943,19 @@ const hans: Record<string, DiscoverStoryI18n> = {
     quote:
       "Hooked up Grok Bot to my customer support emails... and it can connect to Stripe, via API, for agentic operations, e.g. routine refunds.",
     result: "客服收件箱 · Stripe API 退款",
+  },
+  "remote-mower-sawyer-merritt": {
+    title: "远程开割草机",
+    headline: "Sawyer Merritt 设置 Grok Bot，远程控制五十英里外的自动割草机器人",
+    whatTheyDid:
+      "2026 年 8 月 19 日，Sawyer Merritt（@SawyerMerritt）写他把 Grok Bot 设成可以远程控制五十英里外的自动割草机器人。设置用了两分钟。他叫它开始割草，三秒后就动了。然后叫它自己回充电座。他说下一步会接吸尘器，再专用一只 Grok Bot 管所有自动机器人。附件截图是 Engineer Bot 对话：已连 Navimow X450，再「Start mowing now」和「Go dock」。片段是 Navimow X450 地图。",
+    howItWorks: "聊天进、割草机出。我们保留 Sawyer 原帖。没有重跑那次开割或回座。",
+    whyUseful: "远程开和回座就是人人都懂的工：不是聊天摘要——是五十英里外的机器，叫它割，再叫它回家。",
+    whyItMatters: "当日社区例子：具名的人、在用的割草机、Engineer Bot 截图。社区；没有标已测试。",
+    whoShouldTry: ["有割草机器人的人", "出门了但草地还要割的人", "想用一只 Bot 管家用机器人的人"],
+    usefulFor: "个人 / 家庭",
+    quote: "I told it to start mowing and it started 3 seconds later. Then I had it dock itself.",
+    result: "远程开割草 · 回座",
   },
 };
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Add one verified community Discover story: Sawyer Merritt (@SawyerMerritt) set up Grok Bot to remotely start and dock his autonomous robot lawn mower.

- Slug: `remote-mower-sawyer-merritt`
- Source: https://x.com/SawyerMerritt/status/2090179852171174211 (19 Aug 2026)
- Community, `trending: true`, not featured, not tested
- Category: personal
- Result: remote mower start / dock (no invented metrics)
- zh-Hant and zh-Hans copy in `lib/i18n/discover.ts`

## Why

Live-verified X use case that is not already on Discover. The post text includes the 50-mile remote control, 2-minute setup, start-in-3-seconds, dock, and vacuum-next plan. Attached media is an Engineer Bot chat plus the Navimow X450 map.

## Checks

- [x] No invented X authors, handles, tweet IDs, or result numbers
- [x] Community stories link back to the original source
- [x] Tested is only used after UseGrokBot actually ran the Bot
- [x] Translations keep the same message keys

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d6671392-ebab-4bef-ae60-c6fce5f38564?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d6671392-ebab-4bef-ae60-c6fce5f38564&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

