### PR TITLE
feat: add playful workflow interactions

### DIFF
--- a/app/[locale]/submit/page.tsx
+++ b/app/[locale]/submit/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { BlobatarAvatar } from "@/components/BlobatarAvatar";
 import { LocaleLink } from "@/components/LocaleLink";
+import { celebrate } from "@/lib/celebrate";
 import { useI18n } from "@/lib/i18n";
 import { site } from "@/lib/site";
 
@@ -93,6 +94,7 @@ export default function SubmitPage() {
         return;
       }
       setDone(data);
+      void celebrate("submit");
     } catch {
       setError(t("submit.failed"));
     } finally {

--- a/components/CopyButton.tsx
+++ b/components/CopyButton.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { Check, Copy } from "lucide-react";
+import { celebrate } from "@/lib/celebrate";
 import { cn } from "@/lib/cn";
 import { useI18n } from "@/lib/i18n";
 
@@ -11,6 +12,8 @@ type CopyButtonProps = {
   className?: string;
   variant?: "ghost" | "solid" | "inline";
 };
+
+const COPY_CELEBRATION_KEY = "usegrokbot:copy-celebrated";
 
 export function CopyButton({ text, label, className, variant = "ghost" }: CopyButtonProps) {
   const { t } = useI18n();
@@ -29,6 +32,14 @@ export function CopyButton({ text, label, className, variant = "ghost" }: CopyBu
       area.remove();
     }
     setCopied(true);
+    try {
+      if (!window.sessionStorage.getItem(COPY_CELEBRATION_KEY)) {
+        window.sessionStorage.setItem(COPY_CELEBRATION_KEY, "1");
+        void celebrate("copy");
+      }
+    } catch {
+      // Copying still works if sessionStorage is unavailable.
+    }
     window.setTimeout(() => setCopied(false), 1400);
   }
 

--- a/components/DiscoverCard.tsx
+++ b/components/DiscoverCard.tsx
@@ -3,6 +3,7 @@
 import { AppNamePills } from "@/components/AppPills";
 import { AuthorAvatar } from "@/components/AuthorAvatar";
 import { LocaleLink } from "@/components/LocaleLink";
+import { SketchUnderline } from "@/components/SketchUnderline";
 import { StatusBadge } from "@/components/StatusBadge";
 import type { DiscoverStory } from "@/data/discover";
 import { LAST_REVIEWED, formatVerifiedDate, type TrustStatus } from "@/data/verification";
@@ -84,7 +85,9 @@ export function DiscoverCard({
           <p className="text-[10px] font-medium tracking-[0.1em] text-faint uppercase">
             {item.result ? t("discover.result") : t("discover.output")}
           </p>
-          <p className="mt-1 text-[13px] leading-5 text-ink">{item.result ?? item.output}</p>
+          <p className="mt-1 text-[13px] leading-5 text-ink">
+            <SketchUnderline active={featured}>{item.result ?? item.output}</SketchUnderline>
+          </p>
         </div>
       ) : null}
 

--- a/components/SketchUnderline.tsx
+++ b/components/SketchUnderline.tsx
@@ -1,0 +1,39 @@
+import type { ReactNode } from "react";
+
+export function SketchUnderline({ children, active = true }: { children: ReactNode; active?: boolean }) {
+  if (!active) return <>{children}</>;
+
+  return (
+    <span className="relative inline-block pb-1">
+      <span className="relative z-10">{children}</span>
+      <svg
+        className="pointer-events-none absolute -bottom-0.5 left-0 h-2 w-full overflow-visible"
+        viewBox="0 0 100 10"
+        preserveAspectRatio="none"
+        aria-hidden
+      >
+        <path
+          d="M2 6 C 18 9, 34 2, 50 6 S 82 8, 98 4"
+          pathLength="1"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.2"
+          strokeLinecap="round"
+          className="text-accent motion-reduce:hidden"
+          strokeDasharray="1"
+          strokeDashoffset="1"
+        >
+          <animate attributeName="stroke-dashoffset" from="1" to="0" dur="0.62s" begin="0.18s" fill="freeze" />
+        </path>
+        <path
+          d="M2 6 C 18 9, 34 2, 50 6 S 82 8, 98 4"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.2"
+          strokeLinecap="round"
+          className="hidden text-accent motion-reduce:block"
+        />
+      </svg>
+    </span>
+  );
+}

--- a/components/UseCaseDetailView.tsx
+++ b/components/UseCaseDetailView.tsx
@@ -10,6 +10,7 @@ import { PromptBox } from "@/components/PromptBox";
 import { SaveButton } from "@/components/SaveButton";
 import { UseCaseCard } from "@/components/UseCaseCard";
 import { WorkflowSteps } from "@/components/WorkflowSteps";
+import { WorkflowIntegrationMap } from "@/components/WorkflowIntegrationMap";
 import { AppPills } from "@/components/AppPills";
 import { CapabilityRow } from "@/components/CapabilityRow";
 import { StatusBadge } from "@/components/StatusBadge";
@@ -95,6 +96,7 @@ export function UseCaseDetailView({
           {t("detail.integrations")}
         </p>
         <AppPills useCase={useCase} />
+        <WorkflowIntegrationMap useCase={useCase} label={t("detail.integrations")} />
       </div>
       {inspired ? (
         <p className="mt-4 text-[13px] text-mute">

--- a/components/WorkflowIntegrationMap.tsx
+++ b/components/WorkflowIntegrationMap.tsx
@@ -1,0 +1,78 @@
+import { appsBySlug } from "@/data/apps";
+import type { UseCase } from "@/data/types";
+import { displayApps } from "@/lib/capabilities";
+import { BotFace, botColorFor } from "./BotFace";
+import { NamedIcon } from "./icons";
+
+export function WorkflowIntegrationMap({ useCase }: { useCase: UseCase }) {
+  const apps = displayApps(useCase).slice(0, 6);
+  if (apps.length < 2) return null;
+
+  return (
+    <div
+      className="relative mt-4 h-[210px] overflow-hidden rounded-2xl border border-line bg-elevated"
+      role="img"
+      aria-label="Animated map of apps connected through Grok Bot"
+    >
+      <div className="absolute inset-x-0 top-3 text-center text-[10px] font-medium tracking-[0.12em] text-faint uppercase">
+        Workflow map
+      </div>
+
+      <svg
+        className="pointer-events-none absolute inset-0 size-full"
+        viewBox="0 0 100 200"
+        preserveAspectRatio="none"
+        aria-hidden
+      >
+        {apps.map((app, index) => {
+          const x = ((index + 1) / (apps.length + 1)) * 100;
+          const bend = 100 + Math.abs(50 - x) * 0.25;
+          const path = `M ${x} 58 C ${x} ${bend}, 50 ${bend}, 50 148`;
+          return (
+            <g key={app}>
+              <path d={path} fill="none" stroke="currentColor" strokeWidth="0.55" className="text-line" />
+              <path
+                d={path}
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.1"
+                strokeLinecap="round"
+                strokeDasharray="2.5 7"
+                className="text-accent motion-reduce:hidden"
+              >
+                <animate
+                  attributeName="stroke-dashoffset"
+                  values="0;-19"
+                  dur={`${1.15 + index * 0.13}s`}
+                  repeatCount="indefinite"
+                />
+              </path>
+            </g>
+          );
+        })}
+      </svg>
+
+      {apps.map((app, index) => {
+        const x = ((index + 1) / (apps.length + 1)) * 100;
+        const item = appsBySlug[app];
+        return (
+          <div
+            key={app}
+            className="absolute top-[42px] z-10 flex -translate-x-1/2 flex-col items-center gap-1.5"
+            style={{ left: `${x}%` }}
+          >
+            <span className="flex size-10 items-center justify-center rounded-xl border border-line bg-card shadow-sm">
+              <NamedIcon name={item.icon} className="size-4 text-ink" />
+            </span>
+            <span className="max-w-[84px] truncate text-[10px] text-mute">{item.name}</span>
+          </div>
+        );
+      })}
+
+      <div className="absolute bottom-5 left-1/2 z-10 flex -translate-x-1/2 items-center gap-2 rounded-full border border-accent/30 bg-card px-3 py-2 shadow-sm">
+        <BotFace size={20} color={botColorFor(useCase.slug)} />
+        <span className="text-[12px] font-medium text-ink">Grok Bot</span>
+      </div>
+    </div>
+  );
+}

--- a/components/WorkflowIntegrationMap.tsx
+++ b/components/WorkflowIntegrationMap.tsx
@@ -4,7 +4,7 @@ import { displayApps } from "@/lib/capabilities";
 import { BotFace, botColorFor } from "./BotFace";
 import { NamedIcon } from "./icons";
 
-export function WorkflowIntegrationMap({ useCase }: { useCase: UseCase }) {
+export function WorkflowIntegrationMap({ useCase, label }: { useCase: UseCase; label: string }) {
   const apps = displayApps(useCase).slice(0, 6);
   if (apps.length < 2) return null;
 
@@ -12,10 +12,10 @@ export function WorkflowIntegrationMap({ useCase }: { useCase: UseCase }) {
     <div
       className="relative mt-4 h-[210px] overflow-hidden rounded-2xl border border-line bg-elevated"
       role="img"
-      aria-label="Animated map of apps connected through Grok Bot"
+      aria-label={`${label}: apps connected through Grok Bot`}
     >
       <div className="absolute inset-x-0 top-3 text-center text-[10px] font-medium tracking-[0.12em] text-faint uppercase">
-        Workflow map
+        {label}
       </div>
 
       <svg

--- a/lib/celebrate.ts
+++ b/lib/celebrate.ts
@@ -1,0 +1,106 @@
+"use client";
+
+type ConfettiShape = unknown;
+
+type ConfettiOptions = {
+  particleCount?: number;
+  spread?: number;
+  startVelocity?: number;
+  gravity?: number;
+  scalar?: number;
+  ticks?: number;
+  origin?: { x?: number; y?: number };
+  shapes?: ConfettiShape[];
+  disableForReducedMotion?: boolean;
+};
+
+type ConfettiFn = ((options?: ConfettiOptions) => Promise<null> | null) & {
+  shapeFromText?: (options: { text: string; scalar?: number }) => ConfettiShape;
+};
+
+declare global {
+  interface Window {
+    confetti?: ConfettiFn;
+    __useGrokBotConfetti?: Promise<ConfettiFn | null>;
+  }
+}
+
+const SCRIPT_ID = "usegrokbot-canvas-confetti";
+const SCRIPT_SRC = "https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.4/dist/confetti.browser.min.js";
+
+export async function celebrate(kind: "copy" | "submit" = "copy") {
+  if (typeof window === "undefined") return;
+  if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) return;
+
+  const confetti = await loadConfetti();
+  if (!confetti) return;
+
+  const scalar = kind === "submit" ? 1.05 : 0.9;
+  const robot = confetti.shapeFromText?.({ text: "🤖", scalar });
+  const star = confetti.shapeFromText?.({ text: "⭐", scalar });
+  const shapes = [robot, star].filter(Boolean) as ConfettiShape[];
+  const common: ConfettiOptions = {
+    disableForReducedMotion: true,
+    scalar,
+    gravity: 0.95,
+    ticks: 130,
+    shapes: shapes.length ? shapes : undefined,
+  };
+
+  if (kind === "submit") {
+    confetti({
+      ...common,
+      particleCount: 42,
+      spread: 68,
+      startVelocity: 30,
+      origin: { x: 0.5, y: 0.7 },
+    });
+    window.setTimeout(() => {
+      confetti({
+        ...common,
+        particleCount: 22,
+        spread: 48,
+        startVelocity: 24,
+        origin: { x: 0.5, y: 0.76 },
+      });
+    }, 140);
+    return;
+  }
+
+  confetti({
+    ...common,
+    particleCount: 22,
+    spread: 48,
+    startVelocity: 22,
+    origin: { x: 0.5, y: 0.72 },
+  });
+}
+
+async function loadConfetti(): Promise<ConfettiFn | null> {
+  if (window.confetti) return window.confetti;
+  if (window.__useGrokBotConfetti) return window.__useGrokBotConfetti;
+
+  window.__useGrokBotConfetti = new Promise((resolve) => {
+    const existing = document.getElementById(SCRIPT_ID) as HTMLScriptElement | null;
+    if (existing) {
+      if (window.confetti) {
+        resolve(window.confetti);
+        return;
+      }
+      existing.addEventListener("load", () => resolve(window.confetti ?? null), { once: true });
+      existing.addEventListener("error", () => resolve(null), { once: true });
+      return;
+    }
+
+    const script = document.createElement("script");
+    script.id = SCRIPT_ID;
+    script.src = SCRIPT_SRC;
+    script.async = true;
+    script.crossOrigin = "anonymous";
+    script.addEventListener("load", () => resolve(window.confetti ?? null), { once: true });
+    script.addEventListener("error", () => resolve(null), { once: true });
+    document.head.appendChild(script);
+  });
+
+  return window.__useGrokBotConfetti;
+}


### PR DESCRIPTION
Adds a second layer of playful interactions while keeping the site professional and lightweight.

## Included
- lazy-loaded canvas-confetti celebration on the first copied prompt per session
- stronger celebration on successful community submission
- reduced-motion support and graceful no-op if the confetti CDN is unavailable
- animated integration beam map on workflow detail pages, inspired by MagicUI's Animated Beam concept
- hand-drawn animated underline for Featured RESULT/OUTPUT cards, inspired by Rough Notation
- no new npm dependencies or package-lock churn

## Design guardrails
- celebrations are short and event-triggered, never ambient
- workflow beams are bidirectional/neutral so they do not invent data-flow direction
- real content and trust/source information remain the focus
- motion is hidden or disabled for prefers-reduced-motion users