### PR TITLE
refactor: make workflows copy-paste first and add rare Blob unlock

### DIFF
--- a/components/BlobatarAvatar.tsx
+++ b/components/BlobatarAvatar.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { cn } from "@/lib/cn";
+import { celebrate } from "@/lib/celebrate";
 
 const BLOBATAR_ORIGIN = "https://blobatar.dev/avatar";
+const RARE_PREFIX = "usegrokbot:rare-blob:";
 
 type BlobatarExpression = "happy" | "thinking" | "smug" | "love" | "sad" | "idle";
 
@@ -21,7 +23,20 @@ export function BlobatarAvatar({
   title?: string;
 }) {
   const [failed, setFailed] = useState(false);
+  const [tapCount, setTapCount] = useState(0);
+  const [rare, setRare] = useState(false);
+  const [justUnlocked, setJustUnlocked] = useState(false);
   const safeName = name.trim() || "usegrokbot-community";
+  const storageKey = `${RARE_PREFIX}${safeName.toLowerCase()}`;
+
+  useEffect(() => {
+    try {
+      setRare(window.localStorage.getItem(storageKey) === "1");
+    } catch {
+      // localStorage may be unavailable in privacy modes; the Easter egg still works for this visit.
+    }
+  }, [storageKey]);
+
   const initials = useMemo(
     () =>
       safeName
@@ -34,8 +49,32 @@ export function BlobatarAvatar({
         .toUpperCase() || "UG",
     [safeName],
   );
-  const idleSrc = useMemo(() => blobatarUrl(safeName, size), [safeName, size]);
-  const hoverSrc = useMemo(() => blobatarUrl(safeName, size, expression), [safeName, size, expression]);
+  const avatarSeed = rare ? `rare:${safeName}` : safeName;
+  const idleSrc = useMemo(() => blobatarUrl(avatarSeed, size, rare ? "smug" : undefined), [avatarSeed, rare, size]);
+  const hoverSrc = useMemo(
+    () => blobatarUrl(avatarSeed, size, rare ? "love" : expression),
+    [avatarSeed, expression, rare, size],
+  );
+
+  function onSecretTap() {
+    if (rare) return;
+    const next = tapCount + 1;
+    if (next < 5) {
+      setTapCount(next);
+      return;
+    }
+
+    setTapCount(0);
+    setRare(true);
+    setJustUnlocked(true);
+    try {
+      window.localStorage.setItem(storageKey, "1");
+    } catch {
+      // Persistence is a bonus, never a requirement for the avatar itself.
+    }
+    void celebrate("rare");
+    window.setTimeout(() => setJustUnlocked(false), 2400);
+  }
 
   if (failed) {
     return (
@@ -55,32 +94,52 @@ export function BlobatarAvatar({
 
   return (
     <span
-      className={cn(
-        "blobatar group/blobatar relative inline-flex shrink-0 overflow-hidden rounded-full bg-elevated motion-safe:transition-transform motion-safe:duration-200 motion-safe:hover:-translate-y-0.5 motion-safe:hover:rotate-2",
-        className,
-      )}
+      className={cn("relative inline-flex shrink-0", className)}
       style={{ width: size, height: size }}
-      title={title}
+      onPointerUp={onSecretTap}
+      title={rare ? `${title ?? safeName} · Rare Blob ✨` : title}
       aria-hidden={title ? undefined : true}
     >
-      {/* Blobatar's public HTTP endpoint keeps avatars deterministic without adding a client bundle dependency. */}
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img
-        src={idleSrc}
-        alt={title ?? ""}
-        width={size}
-        height={size}
-        className="absolute inset-0 size-full object-cover transition-opacity duration-150 group-hover/blobatar:opacity-0"
-        onError={() => setFailed(true)}
-      />
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img
-        src={hoverSrc}
-        alt=""
-        width={size}
-        height={size}
-        className="absolute inset-0 size-full object-cover opacity-0 transition-opacity duration-150 group-hover/blobatar:opacity-100"
-      />
+      <span
+        className={cn(
+          "blobatar group/blobatar absolute inset-0 overflow-hidden rounded-full bg-elevated motion-safe:transition-transform motion-safe:duration-200 motion-safe:hover:-translate-y-0.5 motion-safe:hover:rotate-2",
+          rare && "ring-2 ring-amber-400/80 ring-offset-2 ring-offset-canvas",
+        )}
+      >
+        {/* Blobatar's public HTTP endpoint keeps avatars deterministic without adding a client bundle dependency. */}
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={idleSrc}
+          alt={title ?? ""}
+          width={size}
+          height={size}
+          className="absolute inset-0 size-full object-cover transition-opacity duration-150 group-hover/blobatar:opacity-0"
+          onError={() => setFailed(true)}
+        />
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={hoverSrc}
+          alt=""
+          width={size}
+          height={size}
+          className="absolute inset-0 size-full object-cover opacity-0 transition-opacity duration-150 group-hover/blobatar:opacity-100"
+        />
+      </span>
+
+      {rare ? (
+        <span
+          className="pointer-events-none absolute -top-1 -right-1 z-10 flex size-5 items-center justify-center rounded-full border border-amber-300/70 bg-card text-[10px] shadow-sm"
+          aria-hidden
+        >
+          ✨
+        </span>
+      ) : null}
+
+      {justUnlocked ? (
+        <span className="pointer-events-none fixed top-20 left-1/2 z-[100] -translate-x-1/2 rounded-full border border-amber-300/50 bg-card px-4 py-2 text-[13px] font-medium whitespace-nowrap text-ink shadow-lg">
+          ✨ Rare Blob unlocked
+        </span>
+      ) : null}
     </span>
   );
 }

--- a/components/UseCaseDetailView.tsx
+++ b/components/UseCaseDetailView.tsx
@@ -5,7 +5,6 @@ import { Breadcrumbs } from "@/components/Breadcrumbs";
 import { CapabilityRow } from "@/components/CapabilityRow";
 import { CopyButton } from "@/components/CopyButton";
 import { ExampleOutput } from "@/components/ExampleOutput";
-import { GetGrokBot } from "@/components/GetGrokBot";
 import { JsonLd } from "@/components/JsonLd";
 import { LocaleLink } from "@/components/LocaleLink";
 import { PromptBox } from "@/components/PromptBox";
@@ -18,6 +17,7 @@ import { getDiscoverStoryForUseCase } from "@/data/discover";
 import type { UseCase } from "@/data/types";
 import { formatVerifiedDate, verificationFor } from "@/data/verification";
 import { categoryFor, localizeUseCase, useI18n } from "@/lib/i18n";
+import { site } from "@/lib/site";
 
 export function UseCaseDetailView({
   useCase,
@@ -93,7 +93,14 @@ export function UseCaseDetailView({
 
         <div className="mt-4 flex flex-wrap items-center gap-3">
           <CopyButton text={useCase.prompt} label={quick.copy} variant="solid" />
-          <GetGrokBot variant="quiet" className="h-11 px-3" />
+          <a
+            href={site.xaiBotUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="spring-press inline-flex h-11 items-center rounded-[10px] border border-line px-4 text-sm font-medium text-ink hover:border-line-strong"
+          >
+            {quick.open} ↗
+          </a>
           <SaveButton slug={useCase.slug} title={item.title} withLabel className="h-11 px-3" />
         </div>
         <p className="mt-3 text-[12px] text-faint">{quick.afterCopy}</p>
@@ -210,6 +217,7 @@ function promptFirstCopy(locale: string) {
       lead: "Copy 呢段提示詞，貼落 Grok Bot 就可以開始。",
       noSetup: "唔使填資料 · 唔使先設定",
       copy: "Copy 提示詞",
+      open: "Open Grok Bot",
       afterCopy: "Copy → 貼去 Grok Bot → 用。想了解原理，再向下睇。",
       explainKicker: "想知先睇",
       explainTitle: "呢段提示詞會幫你做啲乜？",
@@ -221,6 +229,7 @@ function promptFirstCopy(locale: string) {
       lead: "复制这段提示词，粘贴到 Grok Bot 就可以开始。",
       noSetup: "不用填资料 · 不用先设置",
       copy: "复制提示词",
+      open: "打开 Grok Bot",
       afterCopy: "复制 → 粘贴到 Grok Bot → 使用。想了解原理，再往下看。",
       explainKicker: "想了解再看",
       explainTitle: "这段提示词会帮你做什么？",
@@ -231,6 +240,7 @@ function promptFirstCopy(locale: string) {
     lead: "Copy this prompt, paste it into Grok Bot, and go.",
     noSetup: "No form · No setup first",
     copy: "Copy prompt",
+    open: "Open Grok Bot",
     afterCopy: "Copy → paste into Grok Bot → use it. Read on only if you want the explanation.",
     explainKicker: "OPTIONAL EXPLANATION",
     explainTitle: "What will this prompt do for you?",

--- a/components/UseCaseDetailView.tsx
+++ b/components/UseCaseDetailView.tsx
@@ -1,19 +1,19 @@
 "use client";
 
-import { LocaleLink } from "@/components/LocaleLink";
+import { AppPills } from "@/components/AppPills";
 import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { CapabilityRow } from "@/components/CapabilityRow";
 import { CopyButton } from "@/components/CopyButton";
-import { CustomizePrompt } from "@/components/CustomizePrompt";
 import { ExampleOutput } from "@/components/ExampleOutput";
+import { GetGrokBot } from "@/components/GetGrokBot";
 import { JsonLd } from "@/components/JsonLd";
+import { LocaleLink } from "@/components/LocaleLink";
 import { PromptBox } from "@/components/PromptBox";
 import { SaveButton } from "@/components/SaveButton";
-import { UseCaseCard } from "@/components/UseCaseCard";
-import { WorkflowSteps } from "@/components/WorkflowSteps";
-import { WorkflowIntegrationMap } from "@/components/WorkflowIntegrationMap";
-import { AppPills } from "@/components/AppPills";
-import { CapabilityRow } from "@/components/CapabilityRow";
 import { StatusBadge } from "@/components/StatusBadge";
+import { UseCaseCard } from "@/components/UseCaseCard";
+import { WorkflowIntegrationMap } from "@/components/WorkflowIntegrationMap";
+import { WorkflowSteps } from "@/components/WorkflowSteps";
 import { getDiscoverStoryForUseCase } from "@/data/discover";
 import type { UseCase } from "@/data/types";
 import { formatVerifiedDate, verificationFor } from "@/data/verification";
@@ -33,6 +33,7 @@ export function UseCaseDetailView({
   const trust = verificationFor(useCase.slug);
   const localeTag = locale === "en" ? "en" : locale;
   const inspired = getDiscoverStoryForUseCase(useCase.slug);
+  const quick = promptFirstCopy(locale);
 
   return (
     <article className="mx-auto max-w-[800px] px-5 py-10 md:px-8 md:py-16">
@@ -78,62 +79,85 @@ export function UseCaseDetailView({
       </div>
 
       <h1 className="mt-4 text-[clamp(28px,4vw,40px)] font-medium tracking-tight text-ink">{item.title}</h1>
-      <p className="mt-4 text-lg leading-8 text-mute">{item.description}</p>
 
-      <div className="mt-6 flex flex-wrap gap-2 text-[12px] text-mute">
-        {[
-          t(`difficulty.${useCase.difficulty}`),
-          t("meta.setup", { n: setupMins }),
-          t(`schedule.${useCase.schedule}`),
-        ].map((chip) => (
-          <span key={chip} className="rounded-full border border-line px-2.5 py-1">
-            {chip}
-          </span>
-        ))}
-      </div>
-      <div className="mt-3">
-        <p className="mb-1.5 text-[11px] font-medium tracking-[0.08em] text-faint uppercase">
-          {t("detail.integrations")}
-        </p>
-        <AppPills useCase={useCase} />
-        <WorkflowIntegrationMap useCase={useCase} label={t("detail.integrations")} />
-      </div>
-      {inspired ? (
-        <p className="mt-4 text-[13px] text-mute">
-          {inspired.handle
-            ? t("detail.inspiredByHandle", { handle: inspired.handle })
-            : t("detail.inspiredByName", { name: inspired.authorName })}
-        </p>
-      ) : null}
-      <div className="mt-4">
-        <CapabilityRow
-          useCase={useCase}
-          labels={{
-            browser: t("trust.needsBrowser"),
-            login: t("trust.login"),
-            loginYes: t("trust.loginYes"),
-            loginMaybe: t("trust.loginMaybe"),
-            loginNo: t("trust.loginNo"),
-            routine: t("trust.routine"),
-            approval: t("trust.approval"),
-            approvalRecommended: t("trust.approvalRecommended"),
-            approvalOptional: t("trust.approvalOptional"),
-          }}
-        />
-      </div>
-      {trust.source ? (
-        <p className="mt-4 text-[13px] text-mute">
-          {t("trust.source")}{" "}
-          <a href={trust.source.url} className="text-accent" target="_blank" rel="noreferrer">
-            {trust.source.label}
-          </a>
-        </p>
-      ) : null}
+      <section className="mt-7">
+        <div className="mb-3 flex items-end justify-between gap-4">
+          <div>
+            <p className="text-[11px] font-medium tracking-[0.11em] text-accent uppercase">{quick.kicker}</p>
+            <p className="mt-1 text-[15px] font-medium text-ink">{quick.lead}</p>
+          </div>
+          <span className="hidden shrink-0 text-[12px] text-faint sm:inline">{quick.noSetup}</span>
+        </div>
 
-      <div className="mt-8 flex flex-wrap items-center gap-3">
-        <CopyButton text={useCase.prompt} variant="solid" />
-        <SaveButton slug={useCase.slug} title={item.title} withLabel className="h-11 px-3" />
-      </div>
+        <PromptBox prompt={useCase.prompt} />
+
+        <div className="mt-4 flex flex-wrap items-center gap-3">
+          <CopyButton text={useCase.prompt} label={quick.copy} variant="solid" />
+          <GetGrokBot variant="quiet" className="h-11 px-3" />
+          <SaveButton slug={useCase.slug} title={item.title} withLabel className="h-11 px-3" />
+        </div>
+        <p className="mt-3 text-[12px] text-faint">{quick.afterCopy}</p>
+      </section>
+
+      <section className="mt-14 border-t border-line pt-12">
+        <p className="text-[11px] font-medium tracking-[0.11em] text-faint uppercase">{quick.explainKicker}</p>
+        <h2 className="mt-2 text-2xl font-medium tracking-tight text-ink">{quick.explainTitle}</h2>
+        <p className="mt-4 text-[17px] leading-7 text-mute">{item.description}</p>
+
+        <div className="mt-6 flex flex-wrap gap-2 text-[12px] text-mute">
+          {[
+            t(`difficulty.${useCase.difficulty}`),
+            t("meta.setup", { n: setupMins }),
+            t(`schedule.${useCase.schedule}`),
+          ].map((chip) => (
+            <span key={chip} className="rounded-full border border-line px-2.5 py-1">
+              {chip}
+            </span>
+          ))}
+        </div>
+
+        <div className="mt-6">
+          <p className="mb-1.5 text-[11px] font-medium tracking-[0.08em] text-faint uppercase">
+            {t("detail.integrations")}
+          </p>
+          <AppPills useCase={useCase} />
+          <WorkflowIntegrationMap useCase={useCase} label={t("detail.integrations")} />
+        </div>
+
+        {inspired ? (
+          <p className="mt-5 text-[13px] text-mute">
+            {inspired.handle
+              ? t("detail.inspiredByHandle", { handle: inspired.handle })
+              : t("detail.inspiredByName", { name: inspired.authorName })}
+          </p>
+        ) : null}
+
+        <div className="mt-5">
+          <CapabilityRow
+            useCase={useCase}
+            labels={{
+              browser: t("trust.needsBrowser"),
+              login: t("trust.login"),
+              loginYes: t("trust.loginYes"),
+              loginMaybe: t("trust.loginMaybe"),
+              loginNo: t("trust.loginNo"),
+              routine: t("trust.routine"),
+              approval: t("trust.approval"),
+              approvalRecommended: t("trust.approvalRecommended"),
+              approvalOptional: t("trust.approvalOptional"),
+            }}
+          />
+        </div>
+
+        {trust.source ? (
+          <p className="mt-5 text-[13px] text-mute">
+            {t("trust.source")}{" "}
+            <a href={trust.source.url} className="text-accent" target="_blank" rel="noreferrer">
+              {trust.source.label}
+            </a>
+          </p>
+        ) : null}
+      </section>
 
       <section className="mt-16">
         <h2 className="text-2xl font-medium tracking-tight text-ink">{t("detail.what")}</h2>
@@ -151,21 +175,6 @@ export function UseCaseDetailView({
             </li>
           ))}
         </ul>
-      </section>
-
-      <section className="mt-16">
-        <h2 className="text-2xl font-medium tracking-tight text-ink">{t("detail.copyPrompt")}</h2>
-        <div className="mt-6">
-          <PromptBox prompt={useCase.prompt} />
-        </div>
-      </section>
-
-      <section className="mt-16">
-        <h2 className="text-2xl font-medium tracking-tight text-ink">{t("detail.yours")}</h2>
-        <p className="mt-3 text-sm text-mute">{t("detail.yoursBody")}</p>
-        <div className="mt-6">
-          <CustomizePrompt useCase={useCase} />
-        </div>
       </section>
 
       <section className="mt-16">
@@ -192,4 +201,38 @@ export function UseCaseDetailView({
       </section>
     </article>
   );
+}
+
+function promptFirstCopy(locale: string) {
+  if (locale === "zh-Hant") {
+    return {
+      kicker: "即拎即用",
+      lead: "Copy 呢段提示詞，貼落 Grok Bot 就可以開始。",
+      noSetup: "唔使填資料 · 唔使先設定",
+      copy: "Copy 提示詞",
+      afterCopy: "Copy → 貼去 Grok Bot → 用。想了解原理，再向下睇。",
+      explainKicker: "想知先睇",
+      explainTitle: "呢段提示詞會幫你做啲乜？",
+    };
+  }
+  if (locale === "zh-Hans") {
+    return {
+      kicker: "复制即用",
+      lead: "复制这段提示词，粘贴到 Grok Bot 就可以开始。",
+      noSetup: "不用填资料 · 不用先设置",
+      copy: "复制提示词",
+      afterCopy: "复制 → 粘贴到 Grok Bot → 使用。想了解原理，再往下看。",
+      explainKicker: "想了解再看",
+      explainTitle: "这段提示词会帮你做什么？",
+    };
+  }
+  return {
+    kicker: "COPY & RUN",
+    lead: "Copy this prompt, paste it into Grok Bot, and go.",
+    noSetup: "No form · No setup first",
+    copy: "Copy prompt",
+    afterCopy: "Copy → paste into Grok Bot → use it. Read on only if you want the explanation.",
+    explainKicker: "OPTIONAL EXPLANATION",
+    explainTitle: "What will this prompt do for you?",
+  };
 }

--- a/lib/celebrate.ts
+++ b/lib/celebrate.ts
@@ -28,17 +28,18 @@ declare global {
 const SCRIPT_ID = "usegrokbot-canvas-confetti";
 const SCRIPT_SRC = "https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.4/dist/confetti.browser.min.js";
 
-export async function celebrate(kind: "copy" | "submit" = "copy") {
+export async function celebrate(kind: "copy" | "submit" | "rare" = "copy") {
   if (typeof window === "undefined") return;
   if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) return;
 
   const confetti = await loadConfetti();
   if (!confetti) return;
 
-  const scalar = kind === "submit" ? 1.05 : 0.9;
+  const scalar = kind === "rare" ? 1.15 : kind === "submit" ? 1.05 : 0.9;
   const robot = confetti.shapeFromText?.({ text: "🤖", scalar });
-  const star = confetti.shapeFromText?.({ text: "⭐", scalar });
-  const shapes = [robot, star].filter(Boolean) as ConfettiShape[];
+  const star = confetti.shapeFromText?.({ text: kind === "rare" ? "✨" : "⭐", scalar });
+  const crown = kind === "rare" ? confetti.shapeFromText?.({ text: "👑", scalar }) : undefined;
+  const shapes = [robot, star, crown].filter(Boolean) as ConfettiShape[];
   const common: ConfettiOptions = {
     disableForReducedMotion: true,
     scalar,
@@ -46,6 +47,26 @@ export async function celebrate(kind: "copy" | "submit" = "copy") {
     ticks: 130,
     shapes: shapes.length ? shapes : undefined,
   };
+
+  if (kind === "rare") {
+    confetti({
+      ...common,
+      particleCount: 54,
+      spread: 82,
+      startVelocity: 32,
+      origin: { x: 0.5, y: 0.62 },
+    });
+    window.setTimeout(() => {
+      confetti({
+        ...common,
+        particleCount: 28,
+        spread: 56,
+        startVelocity: 25,
+        origin: { x: 0.5, y: 0.7 },
+      });
+    }, 160);
+    return;
+  }
 
   if (kind === "submit") {
     confetti({


### PR DESCRIPTION
Simplifies workflow detail pages around the fastest possible user path and adds the hidden Blob easter egg.

## Workflow UX
- prompt is now immediately below the workflow title
- primary path is Copy Prompt → Open Grok Bot
- removes the personal CustomizePrompt form from workflow detail
- removes the duplicate lower prompt section
- explanation, integrations, steps, audience and output come after the ready-to-use prompt
- explicit copy that no form/setup is required first

## Rare Blob easter egg
- tap the same Blob five times to unlock a rare deterministic variant
- unlock persists in localStorage for that Blob seed
- rare Blob gets a subtle gold ring + sparkle badge
- one-time 👑✨🤖 celebration using the existing lazy confetti loader
- still respects reduced-motion preferences

No workflow data, trust labels, source attribution, or ingestion behavior is changed.