### PR TITLE
fix: open Grok through the installed app when available

### DIFF
--- a/components/GetGrokBot.tsx
+++ b/components/GetGrokBot.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Download } from "lucide-react";
+import { ExternalLink } from "lucide-react";
 import { cn } from "@/lib/cn";
 import { useI18n } from "@/lib/i18n";
 import { site } from "@/lib/site";
@@ -12,14 +12,14 @@ export function GetGrokBot({
   className?: string;
   variant?: "quiet" | "accent" | "link";
 }) {
-  const { t } = useI18n();
+  const { locale } = useI18n();
+  const copy = openGrokCopy(locale);
 
   return (
     <a
       href={site.xaiBotUrl}
-      target="_blank"
-      rel="noreferrer"
-      aria-label={t("official.downloadAria")}
+      aria-label={copy.aria}
+      title={copy.aria}
       className={cn(
         variant === "accent" &&
           "accent-gradient spring-press inline-flex h-11 items-center gap-2 rounded-[10px] px-5 text-sm font-medium",
@@ -29,8 +29,27 @@ export function GetGrokBot({
         className,
       )}
     >
-      {variant === "link" ? null : <Download className="size-3.5" strokeWidth={1.75} />}
-      <span className={variant === "quiet" ? "hidden sm:inline" : undefined}>{t("official.download")}</span>
+      {variant === "link" ? null : <ExternalLink className="size-3.5" strokeWidth={1.75} />}
+      <span className={variant === "quiet" ? "hidden sm:inline" : undefined}>{copy.label}</span>
     </a>
   );
+}
+
+function openGrokCopy(locale: string) {
+  if (locale === "zh-Hant") {
+    return {
+      label: "打開 Grok",
+      aria: "打開 Grok；手機已安裝 Grok app 時會優先用 app 開啟",
+    };
+  }
+  if (locale === "zh-Hans") {
+    return {
+      label: "打开 Grok",
+      aria: "打开 Grok；手机已安装 Grok app 时会优先用 app 打开",
+    };
+  }
+  return {
+    label: "Open Grok",
+    aria: "Open Grok; on mobile, the installed Grok app can handle this link",
+  };
 }

--- a/components/HomeView.tsx
+++ b/components/HomeView.tsx
@@ -68,7 +68,6 @@ export function HomeView({ initialQuery = "" }: { initialQuery?: string }) {
               </div>
               <div className="mt-6 flex flex-wrap items-center gap-3">
                 <GetGrokBot variant="accent" />
-                <p className="text-[12px] text-faint">{t("official.downloadHint")}</p>
               </div>
               <p className="mt-4 text-[12px] text-faint">
                 {t("home.proof", { n: useCases.length })}

--- a/components/UseCaseDetailView.tsx
+++ b/components/UseCaseDetailView.tsx
@@ -95,8 +95,7 @@ export function UseCaseDetailView({
           <CopyButton text={useCase.prompt} label={quick.copy} variant="solid" />
           <a
             href={site.xaiBotUrl}
-            target="_blank"
-            rel="noreferrer"
+            aria-label={quick.openAria}
             className="spring-press inline-flex h-11 items-center rounded-[10px] border border-line px-4 text-sm font-medium text-ink hover:border-line-strong"
           >
             {quick.open} ↗
@@ -217,8 +216,9 @@ function promptFirstCopy(locale: string) {
       lead: "Copy 呢段提示詞，貼落 Grok Bot 就可以開始。",
       noSetup: "唔使填資料 · 唔使先設定",
       copy: "Copy 提示詞",
-      open: "Open Grok Bot",
-      afterCopy: "Copy → 貼去 Grok Bot → 用。想了解原理，再向下睇。",
+      open: "打開 Grok",
+      openAria: "打開 Grok；手機已安裝 Grok app 時會優先用 app 開啟",
+      afterCopy: "Copy → 貼去 Grok → 用。想了解原理，再向下睇。",
       explainKicker: "想知先睇",
       explainTitle: "呢段提示詞會幫你做啲乜？",
     };
@@ -229,8 +229,9 @@ function promptFirstCopy(locale: string) {
       lead: "复制这段提示词，粘贴到 Grok Bot 就可以开始。",
       noSetup: "不用填资料 · 不用先设置",
       copy: "复制提示词",
-      open: "打开 Grok Bot",
-      afterCopy: "复制 → 粘贴到 Grok Bot → 使用。想了解原理，再往下看。",
+      open: "打开 Grok",
+      openAria: "打开 Grok；手机已安装 Grok app 时会优先用 app 打开",
+      afterCopy: "复制 → 粘贴到 Grok → 使用。想了解原理，再往下看。",
       explainKicker: "想了解再看",
       explainTitle: "这段提示词会帮你做什么？",
     };
@@ -240,8 +241,9 @@ function promptFirstCopy(locale: string) {
     lead: "Copy this prompt, paste it into Grok Bot, and go.",
     noSetup: "No form · No setup first",
     copy: "Copy prompt",
-    open: "Open Grok Bot",
-    afterCopy: "Copy → paste into Grok Bot → use it. Read on only if you want the explanation.",
+    open: "Open Grok",
+    openAria: "Open Grok; on mobile, the installed Grok app can handle this link",
+    afterCopy: "Copy → paste into Grok → use it. Read on only if you want the explanation.",
     explainKicker: "OPTIONAL EXPLANATION",
     explainTitle: "What will this prompt do for you?",
   };

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -8,5 +8,5 @@ export const site = {
   brandLine: "See how people are actually using Grok Bot — then build it yourself.",
   githubRepo: "a70win-wq/usegrokbot",
   githubUrl: "https://github.com/a70win-wq/usegrokbot",
-  xaiBotUrl: "https://x.ai/bot",
+  xaiBotUrl: "https://grok.com/",
 } as const;


### PR DESCRIPTION
Fixes the Grok CTA so it behaves like an app launch instead of a download/site link.

## Changes
- switches the shared Grok target from `x.ai/bot` to the official `grok.com` universal/app link
- removes `target=_blank` from the workflow CTA so the OS can handle the navigation normally
- changes CTA copy to `Open Grok` / `打開 Grok` / `打开 Grok`
- changes the global CTA icon from Download to ExternalLink
- removes the stale homepage `Official download on x.ai/bot` hint

## Why
`grok.com` publishes the official iOS Universal Link association for Grok and Android App Links for package `ai.x.grok`. On supported mobile devices, the installed Grok app can therefore handle this link; otherwise it falls back to the web.

No prompt, workflow, ingestion, or trust data changes.