### PR TITLE
fix: send users to the actual Grok Bot app

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -43,6 +43,9 @@ export async function generateMetadata({
     },
     description: messages[locale].home.subtitle,
     applicationName: site.name,
+    other: {
+      "apple-itunes-app": `app-id=${site.grokBotAppId}`,
+    },
     openGraph: {
       siteName: site.name,
       type: "website",

--- a/components/GetGrokBot.tsx
+++ b/components/GetGrokBot.tsx
@@ -19,7 +19,7 @@ export function GetGrokBot({
 }) {
   const { locale } = useI18n();
   const copy = grokBotCopy(locale);
-  const [href, setHref] = useState(site.grokBotDesktopUrl);
+  const [href, setHref] = useState<string>(site.grokBotDesktopUrl);
   const [destination, setDestination] = useState<"desktop" | "ios">("desktop");
 
   useEffect(() => {

--- a/components/GetGrokBot.tsx
+++ b/components/GetGrokBot.tsx
@@ -1,55 +1,80 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { ExternalLink } from "lucide-react";
 import { cn } from "@/lib/cn";
 import { useI18n } from "@/lib/i18n";
 import { site } from "@/lib/site";
 
+type Variant = "quiet" | "accent" | "link" | "outline";
+
 export function GetGrokBot({
   className,
   variant = "quiet",
+  label,
 }: {
   className?: string;
-  variant?: "quiet" | "accent" | "link";
+  variant?: Variant;
+  label?: string;
 }) {
   const { locale } = useI18n();
-  const copy = openGrokCopy(locale);
+  const copy = grokBotCopy(locale);
+  const [href, setHref] = useState(site.grokBotDesktopUrl);
+  const [destination, setDestination] = useState<"desktop" | "ios">("desktop");
+
+  useEffect(() => {
+    const isIOS =
+      /iPhone|iPad|iPod/i.test(navigator.userAgent) ||
+      (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
+
+    if (isIOS) {
+      setHref(site.grokBotIosUrl);
+      setDestination("ios");
+    }
+  }, []);
+
+  const aria = destination === "ios" ? copy.iosAria : copy.desktopAria;
 
   return (
     <a
-      href={site.xaiBotUrl}
-      aria-label={copy.aria}
-      title={copy.aria}
+      href={href}
+      aria-label={aria}
+      title={aria}
       className={cn(
         variant === "accent" &&
           "accent-gradient spring-press inline-flex h-11 items-center gap-2 rounded-[10px] px-5 text-sm font-medium",
         variant === "link" && "inline-flex items-center gap-1 text-sm text-mute hover:text-ink",
         variant === "quiet" &&
           "inline-flex h-8 items-center gap-1.5 rounded-lg border border-line px-2.5 text-[12px] text-mute transition hover:border-line-strong hover:text-ink",
+        variant === "outline" &&
+          "spring-press inline-flex h-11 items-center gap-1.5 rounded-[10px] border border-line px-4 text-sm font-medium text-ink hover:border-line-strong",
         className,
       )}
     >
       {variant === "link" ? null : <ExternalLink className="size-3.5" strokeWidth={1.75} />}
-      <span className={variant === "quiet" ? "hidden sm:inline" : undefined}>{copy.label}</span>
+      <span className={variant === "quiet" ? "hidden sm:inline" : undefined}>{label ?? copy.label}</span>
     </a>
   );
 }
 
-function openGrokCopy(locale: string) {
+function grokBotCopy(locale: string) {
   if (locale === "zh-Hant") {
     return {
-      label: "打開 Grok",
-      aria: "打開 Grok；手機已安裝 Grok app 時會優先用 app 開啟",
+      label: "Grok Bot app",
+      iosAria: "打開或安裝 Grok Bot iPhone app",
+      desktopAria: "打開 Grok Bot 官方電腦版登入及下載頁",
     };
   }
   if (locale === "zh-Hans") {
     return {
-      label: "打开 Grok",
-      aria: "打开 Grok；手机已安装 Grok app 时会优先用 app 打开",
+      label: "Grok Bot app",
+      iosAria: "打开或安装 Grok Bot iPhone app",
+      desktopAria: "打开 Grok Bot 官方电脑版登录及下载页",
     };
   }
   return {
-    label: "Open Grok",
-    aria: "Open Grok; on mobile, the installed Grok app can handle this link",
+    label: "Grok Bot app",
+    iosAria: "Open or install the Grok Bot iPhone app",
+    desktopAria: "Open the official Grok Bot desktop onboarding and download page",
   };
 }

--- a/components/UseCaseDetailView.tsx
+++ b/components/UseCaseDetailView.tsx
@@ -5,6 +5,7 @@ import { Breadcrumbs } from "@/components/Breadcrumbs";
 import { CapabilityRow } from "@/components/CapabilityRow";
 import { CopyButton } from "@/components/CopyButton";
 import { ExampleOutput } from "@/components/ExampleOutput";
+import { GetGrokBot } from "@/components/GetGrokBot";
 import { JsonLd } from "@/components/JsonLd";
 import { LocaleLink } from "@/components/LocaleLink";
 import { PromptBox } from "@/components/PromptBox";
@@ -17,7 +18,6 @@ import { getDiscoverStoryForUseCase } from "@/data/discover";
 import type { UseCase } from "@/data/types";
 import { formatVerifiedDate, verificationFor } from "@/data/verification";
 import { categoryFor, localizeUseCase, useI18n } from "@/lib/i18n";
-import { site } from "@/lib/site";
 
 export function UseCaseDetailView({
   useCase,
@@ -93,13 +93,7 @@ export function UseCaseDetailView({
 
         <div className="mt-4 flex flex-wrap items-center gap-3">
           <CopyButton text={useCase.prompt} label={quick.copy} variant="solid" />
-          <a
-            href={site.xaiBotUrl}
-            aria-label={quick.openAria}
-            className="spring-press inline-flex h-11 items-center rounded-[10px] border border-line px-4 text-sm font-medium text-ink hover:border-line-strong"
-          >
-            {quick.open} ↗
-          </a>
+          <GetGrokBot variant="outline" label={quick.open} />
           <SaveButton slug={useCase.slug} title={item.title} withLabel className="h-11 px-3" />
         </div>
         <p className="mt-3 text-[12px] text-faint">{quick.afterCopy}</p>
@@ -216,9 +210,8 @@ function promptFirstCopy(locale: string) {
       lead: "Copy 呢段提示詞，貼落 Grok Bot 就可以開始。",
       noSetup: "唔使填資料 · 唔使先設定",
       copy: "Copy 提示詞",
-      open: "打開 Grok",
-      openAria: "打開 Grok；手機已安裝 Grok app 時會優先用 app 開啟",
-      afterCopy: "Copy → 貼去 Grok → 用。想了解原理，再向下睇。",
+      open: "打開 Grok Bot",
+      afterCopy: "Copy → 貼去 Grok Bot → 用。想了解原理，再向下睇。",
       explainKicker: "想知先睇",
       explainTitle: "呢段提示詞會幫你做啲乜？",
     };
@@ -229,9 +222,8 @@ function promptFirstCopy(locale: string) {
       lead: "复制这段提示词，粘贴到 Grok Bot 就可以开始。",
       noSetup: "不用填资料 · 不用先设置",
       copy: "复制提示词",
-      open: "打开 Grok",
-      openAria: "打开 Grok；手机已安装 Grok app 时会优先用 app 打开",
-      afterCopy: "复制 → 粘贴到 Grok → 使用。想了解原理，再往下看。",
+      open: "打开 Grok Bot",
+      afterCopy: "复制 → 粘贴到 Grok Bot → 使用。想了解原理，再往下看。",
       explainKicker: "想了解再看",
       explainTitle: "这段提示词会帮你做什么？",
     };
@@ -241,9 +233,8 @@ function promptFirstCopy(locale: string) {
     lead: "Copy this prompt, paste it into Grok Bot, and go.",
     noSetup: "No form · No setup first",
     copy: "Copy prompt",
-    open: "Open Grok",
-    openAria: "Open Grok; on mobile, the installed Grok app can handle this link",
-    afterCopy: "Copy → paste into Grok → use it. Read on only if you want the explanation.",
+    open: "Open Grok Bot",
+    afterCopy: "Copy → paste into Grok Bot → use it. Read on only if you want the explanation.",
     explainKicker: "OPTIONAL EXPLANATION",
     explainTitle: "What will this prompt do for you?",
   };

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -8,5 +8,7 @@ export const site = {
   brandLine: "See how people are actually using Grok Bot — then build it yourself.",
   githubRepo: "a70win-wq/usegrokbot",
   githubUrl: "https://github.com/a70win-wq/usegrokbot",
-  xaiBotUrl: "https://grok.com/",
+  grokBotDesktopUrl: "https://cursor.com/bot/onboarding",
+  grokBotIosUrl: "https://apps.apple.com/app/grok-bot/id6794501026",
+  grokBotAppId: "6794501026",
 } as const;


### PR DESCRIPTION
Corrects the Grok/Grok Bot product mix-up.

## Changes
- removes the incorrect `grok.com` destination entirely
- iPhone/iPad users go to the official Grok Bot App Store listing (Anysphere, app id 6794501026)
- desktop users go to the official Grok Bot onboarding/download flow
- workflow pages reuse one device-aware Grok Bot CTA
- restores all workflow wording to `Grok Bot`, not `Grok`
- adds the iOS Smart App Banner metadata for the official Grok Bot app

## Important limitation
Cursor/Anysphere does not currently publish a documented Grok Bot-specific URL scheme/deep link. We deliberately do not invent `grokbot://` or reuse Cursor IDE deep links. When an official Grok Bot deep link is documented, the centralized CTA can be upgraded without changing every workflow page.