### PR TITLE
Add Gavin Baker podcast summarizer Discover story

### DIFF
--- a/data/discover.ts
+++ b/data/discover.ts
@@ -92,6 +92,7 @@ const MARIO_3D_GAME = "https://x.com/RoundtableSpace/status/2090117840091419126"
 const KUN_FIRSTMATE = "https://x.com/kunchenguid/status/2089792928092963234";
 const GERGELY_REFUNDS = "https://x.com/GergelyOrosz/status/2090085668768694562";
 const SAWYER_MOWER = "https://x.com/SawyerMerritt/status/2090179852171174211";
+const GAVIN_PODCAST = "https://x.com/GavinSBaker/status/2089379355692527813";
 const YUNTA_CALENDAR = "https://x.com/yunta_tsai/status/2087415205756391461";
 const YUNTA_MATH = "https://x.com/yunta_tsai/status/2088832993108590853";
 const YUNTA_PARENTS = "https://x.com/yunta_tsai/status/2089927285113803053";
@@ -233,6 +234,38 @@ const curatedStories: DiscoverStory[] = [
     sourceLabel: "Rahul on X",
     trending: true,
     featured: true,
+  },
+  {
+    slug: "podcast-summarizer-gavin-baker",
+    title: "Podcast Summarizer in 15 Seconds",
+    headline:
+      "Gavin Baker built a podcast summarizer in Grok Bot in about 15 seconds — and said it beat what he had",
+    whatTheyDid:
+      "On 17 Aug 2026 Gavin Baker (@GavinSBaker) wrote that @bot is another “Claude Code” moment for AI, and that his personal AI usage is up something like 100x. The concrete job: people had asked him how to build a podcast summarizer. In Grok Bot it took him about 15 seconds, and it was better than what he had before.",
+    howItWorks:
+      "This is a named investor showing a real first job, not a launch demo. We keep Gavin’s permalink. We did not re-run his summarizer.",
+    whyUseful:
+      "A daily podcast pile is the job investors and operators already have. This is the public case for handing it to a Bot instead of another custom tool.",
+    whyItMatters:
+      "One of the highest-attention community Grok Bot use-case posts this week. Community; we did not mark it tested.",
+    whoShouldTry: ["Investors", "Operators who listen more than they have time for", "Anyone who has been meaning to build a summarizer"],
+    usefulFor: "Research / Operators",
+    quote:
+      "And for everyone who reached out about how to build a “podcast summarizer” it took me about 15 seconds in Grok Bot and is better than what I had before.",
+    result: "Podcast summarizer · about 15 seconds",
+    category: "research",
+    outcomes: ["research", "save-time"],
+    apps: ["browser"],
+    difficulty: "easy",
+    schedule: "always-on",
+    source: "community",
+    authorName: "Gavin Baker",
+    handle: "GavinSBaker",
+    publishedAt: "2026-08-17",
+    xPostUrl: GAVIN_PODCAST,
+    sourceUrl: GAVIN_PODCAST,
+    sourceLabel: "Gavin Baker on X",
+    trending: true,
   },
   {
     slug: "support-refunds-gergely-orosz",

--- a/lib/i18n/discover.ts
+++ b/lib/i18n/discover.ts
@@ -247,6 +247,20 @@ const hant: Record<string, DiscoverStoryI18n> = {
     quote: "You find the leads. Write the outreach. Make the images. Answer the replies. Count the week.",
     result: "六隻起步 Bot · 一人公司",
   },
+  "podcast-summarizer-gavin-baker": {
+    title: "十五秒做出 Podcast 摘要",
+    headline: "Gavin Baker 用大約十五秒在 Grok Bot 砌了 Podcast 摘要工具——話比舊那套更好",
+    whatTheyDid:
+      "2026 年 8 月 17 日，Gavin Baker（@GavinSBaker）寫 @bot 是 AI 的另一個 “Claude Code” moment，個人 AI 用量大概增加了 100 倍。具體的工：之前有人問他怎樣做 Podcast summarizer。在 Grok Bot 裡大約十五秒就做好，而且比他之前用的更好。",
+    howItWorks: "這是具名投資人交出的第一份真工，不是發布示範。我們保留 Gavin 原帖。沒有重跑他的摘要工具。",
+    whyUseful: "每天一堆 Podcast，是投資人和營運已經有的工。這就是公開例子：交給 Bot，而不是再砌一套自己的工具。",
+    whyItMatters: "這週最受注意的社群 Grok Bot 用例帖之一。社群；沒有標已測試。",
+    whoShouldTry: ["投資人", "聽的比時間多的營運", "一直想做摘要工具的人"],
+    usefulFor: "研究 / 營運",
+    quote:
+      "And for everyone who reached out about how to build a “podcast summarizer” it took me about 15 seconds in Grok Bot and is better than what I had before.",
+    result: "Podcast 摘要 · 大約十五秒",
+  },
   "clothes-resale-scotty-beam": {
     title: "賣掉未着過的衫",
     headline: "SCOTTY BEAM 寫 Cursor 同事把妹妹未着過的衫交給 Grok Bot",
@@ -718,6 +732,20 @@ const hans: Record<string, DiscoverStoryI18n> = {
     usefulFor: "一人创始人 / 运营",
     quote: "You find the leads. Write the outreach. Make the images. Answer the replies. Count the week.",
     result: "六只起步 Bot · 一人公司",
+  },
+  "podcast-summarizer-gavin-baker": {
+    title: "十五秒做出 Podcast 摘要",
+    headline: "Gavin Baker 用大约十五秒在 Grok Bot 做了 Podcast 摘要工具——说比旧那套更好",
+    whatTheyDid:
+      "2026 年 8 月 17 日，Gavin Baker（@GavinSBaker）写 @bot 是 AI 的另一个 “Claude Code” moment，个人 AI 用量大概增加了 100 倍。具体的活：之前有人问他怎么做 Podcast summarizer。在 Grok Bot 里大约十五秒就做好，而且比他之前用的更好。",
+    howItWorks: "这是具名投资人交出的第一份真活，不是发布演示。我们保留 Gavin 原帖。没有重跑他的摘要工具。",
+    whyUseful: "每天一堆 Podcast，是投资人和运营已经有的活。这就是公开例子：交给 Bot，而不是再做一套自己的工具。",
+    whyItMatters: "这周最受注意的社区 Grok Bot 用例帖之一。社区；没有标已测试。",
+    whoShouldTry: ["投资人", "听的比时间多的运营", "一直想做摘要工具的人"],
+    usefulFor: "研究 / 运营",
+    quote:
+      "And for everyone who reached out about how to build a “podcast summarizer” it took me about 15 seconds in Grok Bot and is better than what I had before.",
+    result: "Podcast 摘要 · 大约十五秒",
   },
   "clothes-resale-scotty-beam": {
     title: "卖掉没穿过的衣服",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Add one verified community Discover story: Gavin Baker (@GavinSBaker) built a podcast summarizer in Grok Bot in about 15 seconds.

- Slug: `podcast-summarizer-gavin-baker`
- Source: https://x.com/GavinSBaker/status/2089379355692527813 (17 Aug 2026)
- Community, `trending: true`, not featured, not tested
- Category: research
- Result: podcast summarizer · about 15 seconds (no invented metrics)
- zh-Hant and zh-Hans copy in `lib/i18n/discover.ts`
- Quote is the original English sentence from the post

## Why

Live-verified X use case that is not already on Discover. The post says @bot is another “Claude Code” moment, personal AI usage is up something like 100x, and the podcast summarizer took about 15 seconds and beat what he had before.

## Checks

- [x] No invented X authors, handles, tweet IDs, or result numbers
- [x] Community stories link back to the original source
- [x] Tested is only used after UseGrokBot actually ran the Bot
- [x] Translations keep the same message keys

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1fe02e59-1609-49da-8d26-a25f8fe90281?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1fe02e59-1609-49da-8d26-a25f8fe90281&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

