### PR TITLE
Make workflow prompts copy-ready by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,4 @@ jobs:
       - run: npm ci
       - run: npx tsc --noEmit
       - run: npx tsx scripts/validate-discover.ts
+      - run: npx tsx scripts/validate-prompts.ts

--- a/data/use-cases/index.ts
+++ b/data/use-cases/index.ts
@@ -9,7 +9,74 @@ import { restUseCases } from "./rest";
 import { salesUseCases } from "./sales";
 import { supportHrUseCases } from "./support-hr";
 
-export const useCases: UseCase[] = [
+const copyReadyPromptOverrides: Record<string, string> = {
+  "follow-up-email-writer": `You are my Follow-up Email Writer.
+
+Write emails people will actually answer.
+
+When I paste an email, conversation, meeting note, or briefly tell you what happened:
+- Work out who I am writing to and what just happened.
+- Identify the most natural next step.
+- Make one clear ask.
+- Keep the tone plain, warm, and short.
+- Use only facts I provided.
+
+Rules:
+- 80–130 words
+- One ask only
+- No “just circling back” unless this is genuinely a bump
+- No fake urgency
+- No unnecessary links
+- Do not invent facts
+
+Return:
+1. Subject line
+2. Email
+3. A shorter bump I can send 4 days later
+4. One short sentence explaining why this version should work
+
+If I have not given you enough context yet, ask me one short question or ask me to paste the previous email, conversation, or notes. Do not give me a form or a list of blanks to fill in.`,
+};
+
+const placeholderPattern = /(^|[\s:,(=\-])\[([A-Za-z][A-Za-z0-9 ,/&'().:+\-]{0,80})\]/gm;
+
+function makePlaceholderCopyReady(prefix: string, label: string) {
+  const normalized = label.toLowerCase();
+
+  if (/if known|if available|optional/.test(normalized)) {
+    return `${prefix}infer it from my context if available; otherwise skip it`;
+  }
+
+  if (/paste|notes|email|thread|transcript|text|content|context|document|brief/.test(normalized)) {
+    return `${prefix}use what I paste or tell you after this prompt`;
+  }
+
+  return `${prefix}infer from what I paste or tell you next`;
+}
+
+function makePromptCopyReady(slug: string, prompt: string) {
+  const override = copyReadyPromptOverrides[slug];
+  if (override) return override;
+
+  placeholderPattern.lastIndex = 0;
+  if (!placeholderPattern.test(prompt)) return prompt;
+  placeholderPattern.lastIndex = 0;
+
+  const normalizedPrompt = prompt.replace(
+    placeholderPattern,
+    (_match, prefix: string, label: string) => makePlaceholderCopyReady(prefix, label),
+  );
+
+  return `Use the context I paste or tell you after this prompt.
+Infer whatever you reasonably can from it.
+If one critical detail is missing, ask me one short question at a time.
+Do not give me a form, checklist of blanks, or ask me to fill in placeholders.
+Do not invent facts.
+
+${normalizedPrompt}`;
+}
+
+const rawUseCases: UseCase[] = [
   ...publicDemoUseCases,
   ...salesUseCases,
   ...marketingUseCases,
@@ -19,6 +86,11 @@ export const useCases: UseCase[] = [
   ...supportHrUseCases,
   ...restUseCases,
 ];
+
+export const useCases: UseCase[] = rawUseCases.map((useCase) => ({
+  ...useCase,
+  prompt: makePromptCopyReady(useCase.slug, useCase.prompt),
+}));
 
 const bySlug = new Map(useCases.map((useCase) => [useCase.slug, useCase]));
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "lint": "eslint",
     "validate:discover": "tsx scripts/validate-discover.ts",
+    "validate:prompts": "tsx scripts/validate-prompts.ts",
     "sync:awesome-grok-bot": "node scripts/sync-awesome-grok-bot.mjs",
     "ingest:awesome-grok-bot": "tsx scripts/ingest-awesome-grok-bot.ts"
   },

--- a/scripts/validate-prompts.ts
+++ b/scripts/validate-prompts.ts
@@ -1,0 +1,16 @@
+import { useCases } from "../data/use-cases";
+
+const placeholderPattern = /(^|[\s:,(=\-])\[([A-Za-z][A-Za-z0-9 ,/&'().:+\-]{0,80})\]/gm;
+
+const failures = useCases.flatMap((useCase) => {
+  placeholderPattern.lastIndex = 0;
+  return placeholderPattern.test(useCase.prompt) ? [useCase.slug] : [];
+});
+
+if (failures.length > 0) {
+  throw new Error(
+    `These workflows still expose fill-in-the-blank placeholders: ${failures.join(", ")}`,
+  );
+}
+
+console.log(`Validated ${useCases.length} copy-ready workflow prompts.`);


### PR DESCRIPTION
## What changed
- transforms fill-in-the-blank placeholders into copy-ready instructions at runtime
- adds a hand-tuned Follow-up Email Writer prompt with no form-style fields
- tells Grok Bot to infer context first and ask only one short question if essential context is missing
- adds CI validation so exposed workflow prompts cannot regress to bracket placeholders

## UX goal
Copy → paste into Grok Bot → use. No forms and no manual placeholder editing.