### PR TITLE
docs: add Cursor Cloud dev environment notes to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,3 +7,12 @@ This version has breaking changes — APIs, conventions, and file structure may 
 This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
 
 <!-- END:nextjs-agent-rules -->
+
+## Cursor Cloud specific instructions
+
+Single Next.js 16 App Router site (React 19, Tailwind 4, Turbopack); npm is the package manager (`package-lock.json`). There is no database or external service to run — the site is served entirely from local structured content under `data/`.
+
+- Dev server: `npm run dev` (Turbopack) serves on `http://localhost:3000`. `/` 307-redirects to a locale prefix (`/en`, `/zh-hk`, `/zh-cn`); browse `/en` directly. Standard scripts live in `package.json`; run/verify commands are documented in `README.md` and `CONTRIBUTING.md`.
+- `npm run lint` currently exits non-zero due to pre-existing `react-hooks/set-state-in-effect` errors in a few components — not from your changes. CI (`.github/workflows/ci.yml`) does not run lint; it runs `npx tsc --noEmit`, `validate:discover`, and `validate:prompts`. `CONTRIBUTING.md` still asks contributors to run `npm run lint` and `npm run build` before submitting.
+- Environment variables are optional and only needed for ingestion/`/api/ingest` (e.g. `INGEST_BOT_TOKEN`, `INGEST_GITHUB_TOKEN`/`GITHUB_TOKEN`, AI Gateway for `INGEST_MODEL`). None are required to build, lint, type-check, or run the site locally.
+- Non-obvious routing: `next.config.ts` redirects several top-level routes (`/use-cases`, `/use-cases/:slug`, `/prompts`, `/saved`, `/discover`, `/learn`, `/apps`) back to the locale home. Because of this, the `UseCaseCard`/`SaveButton` (heart) workflow cards are not reachable from `/use-cases`; they render on category pages, the Saved page, and discover detail pages. Homepage search is a typeahead dropdown of live results (categories + X posts) that navigates on click.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Set up the Cloud Agent development environment for this Next.js 16 site and captured durable, non-obvious guidance for future agents. The only code/repo change is a new `## Cursor Cloud specific instructions` section appended to `AGENTS.md`.

Verified the full dev toolchain end-to-end:

| Step | Command | Result |
| --- | --- | --- |
| Install | `npm ci` | 393 packages, 0 vulnerabilities |
| Type check | `npx tsc --noEmit` | pass (exit 0) |
| Validate content | `npm run validate:discover` / `npm run validate:prompts` | 172 stories / 65 prompts OK |
| Build | `npm run build` | pass (exit 0) |
| Lint | `npm run lint` | exits non-zero on **pre-existing** `react-hooks/set-state-in-effect` errors (not from this PR; CI does not run lint) |
| Run | `npm run dev` | serves on `http://localhost:3000`, `/` → `/en` |

Hello-world check: on the running dev server, searched the discovery hub for "email", saw the live typeahead dropdown of matching results, and clicked the "Email" category to navigate to `/en/categories/email` (32 posts).

## Why

Future cloud agents need to know this is a self-contained Next.js app (no DB/services), that env vars are only for optional ingestion, that lint has pre-existing errors while CI relies on `tsc` + validation scripts, and that several top-level routes redirect to the locale home (so the `SaveButton` workflow cards aren't reachable from `/use-cases`).

## Checks

- [x] No invented X authors, handles, tweet IDs, or result numbers
- [x] Community stories link back to the original source
- [x] Tested is only used after UseGrokBot actually ran the Bot
- [x] Translations keep the same message keys
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6926b253-fc5a-4336-a704-d7f8d29bfbe5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6926b253-fc5a-4336-a704-d7f8d29bfbe5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

