### PR TITLE
Raise Ingest posts: batch cap to 1000 URLs

### DIFF
--- a/.github/ISSUE_TEMPLATE/ingest-posts.md
+++ b/.github/ISSUE_TEMPLATE/ingest-posts.md
@@ -5,7 +5,7 @@ title: "Ingest posts:"
 labels: ["use-case"]
 ---
 
-Paste one public X post URL per line. Max 15.
+Paste one public X post URL per line. Max 1000.
 
 https://x.com/
 

--- a/.github/ISSUE_TEMPLATE/use-case.md
+++ b/.github/ISSUE_TEMPLATE/use-case.md
@@ -7,7 +7,7 @@ labels: ["use-case"]
 
 ## X post URL
 
-One public X post URL, or several URLs (one per line). Max 15.
+One public X post URL, or several URLs (one per line). Max 1000.
 
 https://x.com/
 

--- a/.github/workflows/ingest.yml
+++ b/.github/workflows/ingest.yml
@@ -41,6 +41,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AI_GATEWAY_API_KEY: ${{ secrets.AI_GATEWAY_API_KEY }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
           ISSUE_BODY: ${{ github.event.issue.body }}
           INGEST_URL: ${{ github.event.inputs.url }}

--- a/app/api/ingest/route.ts
+++ b/app/api/ingest/route.ts
@@ -1,4 +1,4 @@
-import { collectXUrls, ingestUseCase, queueIngestIssue } from "@/lib/ingest";
+import { collectXUrls, INGEST_URL_LIMIT, ingestUseCase, queueIngestIssue } from "@/lib/ingest";
 import { rateLimit } from "@/lib/ingest/rate-limit";
 
 export const maxDuration = 60;
@@ -24,6 +24,7 @@ function isIngestBot(request: Request) {
 function urlsFromBody(body: Body) {
   return collectXUrls(
     [body.xUrl ?? "", ...(Array.isArray(body.xUrls) ? body.xUrls : []), body.urls ?? ""].join("\n"),
+    INGEST_URL_LIMIT,
   );
 }
 

--- a/data/how-we-built-prompt.ts
+++ b/data/how-we-built-prompt.ts
@@ -41,7 +41,7 @@ For each post save:
 File GitHub issues on a70win-wq/usegrokbot.
 
 Title must be exactly: Ingest posts:
-Max 15 original URLs per issue. More posts = more issues.
+Max 1000 original URLs per issue. More posts = more issues.
 
 Body:
 

--- a/lib/ingest/index.ts
+++ b/lib/ingest/index.ts
@@ -1,5 +1,5 @@
 export { ingestUseCase, type IngestInput, type IngestResult } from "./pipeline";
-export { collectXUrls, isIngestIssueTitle, parseXUrl } from "./x-url";
+export { collectXUrls, INGEST_URL_LIMIT, isIngestIssueTitle, parseXUrl } from "./x-url";
 export { fetchXPost } from "./fetch-post";
 export { canPublish, queueIngestIssue } from "./publish";
 export { assertStorySafe, existingStoryKeys } from "./validate";

--- a/lib/ingest/publish.ts
+++ b/lib/ingest/publish.ts
@@ -1,5 +1,6 @@
 import { site } from "@/lib/site";
 import type { DiscoverStory } from "@/data/discover";
+import { INGEST_URL_LIMIT } from "./x-url";
 
 const FILE_PATH = "data/discover/ingested.json";
 
@@ -119,7 +120,7 @@ export async function publishStory(story: DiscoverStory): Promise<{ prUrl: strin
 
 export async function queueIngestIssue(urls: string[]) {
   const { owner, name } = repo();
-  const unique = [...new Set(urls)].slice(0, 15);
+  const unique = [...new Set(urls)].slice(0, INGEST_URL_LIMIT);
   if (unique.length === 0) throw new Error("no_urls");
   const issue = await gh<{ html_url: string; number: number }>(`/repos/${owner}/${name}/issues`, {
     method: "POST",

--- a/lib/ingest/x-url.ts
+++ b/lib/ingest/x-url.ts
@@ -39,7 +39,9 @@ export function hasXArticleLink(text: string) {
 
 const X_URL_RE = /https?:\/\/(?:www\.)?(?:x\.com|twitter\.com)\/[^\s<>"'`)\]|]+/gi;
 
-export function collectXUrls(text: string, limit = 15): string[] {
+export const INGEST_URL_LIMIT = 1000;
+
+export function collectXUrls(text: string, limit = INGEST_URL_LIMIT): string[] {
   const found = new Map<string, string>();
   for (const raw of text.match(X_URL_RE) ?? []) {
     const parsed = parseXUrl(raw.replace(/[.,;:!?]+$/, ""));

--- a/scripts/ingest-issue.ts
+++ b/scripts/ingest-issue.ts
@@ -1,12 +1,12 @@
 import { readFileSync, writeFileSync } from "node:fs";
 import { ingestUseCase } from "../lib/ingest/pipeline";
 import { assertStorySafe } from "../lib/ingest/validate";
-import { collectXUrls, isIngestIssueTitle, tweetIdFromUrl } from "../lib/ingest/x-url";
+import { collectXUrls, INGEST_URL_LIMIT, isIngestIssueTitle, tweetIdFromUrl } from "../lib/ingest/x-url";
 import { discoverStories, type DiscoverStory } from "../data/discover";
 import { site } from "../lib/site";
 
 const INGESTED_PATH = "data/discover/ingested.json";
-const MAX_URLS = 200;
+const MAX_URLS = INGEST_URL_LIMIT;
 
 type Row = {
   url: string;
@@ -71,6 +71,19 @@ async function githubApi<T>(path: string, init?: RequestInit): Promise<T> {
   }
   if (response.status === 204) return undefined as T;
   return (await response.json()) as T;
+}
+
+async function loadOpenedIssue() {
+  const number = process.env.ISSUE_NUMBER;
+  if (number && process.env.GITHUB_TOKEN) {
+    const [owner, name] = site.githubRepo.split("/");
+    const issue = await githubApi<GitHubIssue>(`/repos/${owner}/${name}/issues/${number}`);
+    return { title: issue.title, body: issue.body ?? "" };
+  }
+  return {
+    title: process.env.ISSUE_TITLE ?? "",
+    body: process.env.ISSUE_BODY ?? "",
+  };
 }
 
 async function listOpenIngestIssues() {
@@ -149,8 +162,7 @@ async function ingestUrl(
 
 async function main() {
   const eventName = process.env.GITHUB_EVENT_NAME ?? "";
-  const title = process.env.ISSUE_TITLE ?? "";
-  const body = process.env.ISSUE_BODY ?? "";
+  const { title, body } = await loadOpenedIssue();
   const directUrls = collectXUrls([process.env.INGEST_URL ?? "", process.env.INGEST_URLS ?? ""].join("\n"), MAX_URLS);
 
   let issue = parseIssue(title, body);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Raise the shared **Ingest posts:** batch cap to **1000** unique X permalinks so one issue can submit a full batch without silent truncation at 15 or 200.

- `collectXUrls` default is now `INGEST_URL_LIMIT` (1000)
- `scripts/ingest-issue.ts` uses that same cap (was 200)
- API `/api/ingest` and `queueIngestIssue` slice at 1000
- Issue templates and the how-we-built prompt say Max 1000
- Titles/labels stay `Ingest posts:` / `use-case`
- Opened issues are loaded from the GitHub API so a 1000-URL body is not clipped by Actions env-var size
- `SOURCE_INGEST_LIMIT` / awesome-grok-bot auto-ingest is unchanged (still 20)

A 1001st unique URL is still dropped.

## Why

A single `Ingest posts:` issue should accept up to 1000 `https://x.com/{handle}/status/{id}` URLs and parse/process all of them. Extra URLs inside that cap must not be silently dropped.

## Checks

- [x] No invented X authors, handles, tweet IDs, or result numbers
- [x] Community stories link back to the original source
- [x] Tested is only used after UseGrokBot actually ran the Bot
- [x] Translations keep the same message keys
- [x] Collection test: 1000 unique URLs kept, 1001st dropped
- [x] GitHub Actions `validate` passed
- [x] How-we-built page shows Max 1000 and title `Ingest posts:`

## Preview

https://usegrokbot-git-cursor-ingest-batch-cap-1000-9a8a-aipost.vercel.app

Not pushed to `main`. Please test the preview, then say if you want this shipped.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e154573b-199e-4c9e-b16b-b4f6adb19a8a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e154573b-199e-4c9e-b16b-b4f6adb19a8a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

