### PR TITLE
Auto-include Discover zh X Articles in Chinese ranking

### DIFF
--- a/data/chinese-tutorial-articles.ts
+++ b/data/chinese-tutorial-articles.ts
@@ -44,10 +44,11 @@ function tutorialArticle(input: TutorialArticleInput): DiscoverStory {
 /**
  * Chinese Grok Bot tutorials verified through Grok X Search on 2026-09-04,
  * with longform Article backfill on 2026-09-07 (cgnot996 credits / Hangzhou)
- * and 2026-09-08 (Adrian Punk self-media team; Chris FAQ).
+ * and 2026-09-08 (Adrian Punk self-media team; Chris FAQ; JuneDangg Topic Scout).
  *
  * These records are intentionally article-only. They are merged into the
  * Articles surfaces without increasing the Discover catalogue inventory.
+ * Runtime ranking also unions Discover zh X Articles; curated titles win.
  */
 export const chineseTutorialArticles: DiscoverStory[] = [
   tutorialArticle({
@@ -337,6 +338,24 @@ export const chineseTutorialArticles: DiscoverStory[] = [
     category: "operations",
     outcomes: ["save-time", "automate-work"],
     difficulty: "easy",
+  }),
+  tutorialArticle({
+    slug: "zh-tutorial-junedangg-topic-scout",
+    title: "我用了9%的Grok Bot周用量，手搓出第一只AI选题编辑",
+    localizedArticleTitles: {
+      en: "I used 9% of my weekly Grok Bot quota to hand-build my first AI Topic Scout editor",
+      "zh-Hant": "我用了9%的 Grok Bot 週用量，手搓出第一隻 AI 選題編輯",
+      "zh-Hans": "我用了9%的Grok Bot周用量，手搓出第一只AI选题编辑",
+      ja: "週次 Grok Bot 枠の9%で、最初のAIトピック編集ボットを手づくりした",
+    },
+    authorName: "君定老師",
+    handle: "JuneDangg",
+    publishedAt: "2026-09-08",
+    xPostUrl: "https://x.com/JuneDangg/status/2097145937034723607",
+    articleUrl: "https://x.com/i/article/2097125111187001344",
+    category: "content",
+    outcomes: ["create-content", "automate-work"],
+    difficulty: "medium",
   }),
 ];
 

--- a/lib/articles.ts
+++ b/lib/articles.ts
@@ -1,10 +1,17 @@
 import { chineseTutorialArticles } from "@/data/chinese-tutorial-articles";
-import { articleExternalUrl, type DiscoverStory } from "@/data/discover";
+import {
+  articleExternalUrl,
+  discoverStories,
+  resolvedXArticleUrl,
+  xArticleIdFromUrl,
+  type DiscoverStory,
+} from "@/data/discover";
 import {
   storyContentLanguage,
   type ArticleContentLanguage,
 } from "@/lib/article-language";
 import type { Locale } from "@/lib/i18n/types";
+import { tweetIdFromUrl } from "@/lib/ingest/x-url";
 import {
   articleRankingStories,
   articleStoriesByViews,
@@ -39,8 +46,47 @@ export function englishArticlesByViews(limit?: number) {
   return typeof limit === "number" ? ranked.slice(0, limit) : ranked;
 }
 
+function isChineseTeachingXArticle(story: DiscoverStory) {
+  if (!resolvedXArticleUrl(story)) return false;
+  const language = storyContentLanguage(story);
+  return language === "zh-Hans" || language === "zh-Hant";
+}
+
+function teachingArticleKeys(story: DiscoverStory) {
+  const keys = [`slug:${story.slug}`];
+  const articleId = xArticleIdFromUrl(resolvedXArticleUrl(story));
+  const tweetId = tweetIdFromUrl(story.xPostUrl ?? story.sourceUrl ?? "");
+  if (articleId) keys.push(`article:${articleId}`);
+  if (tweetId) keys.push(`tweet:${tweetId}`);
+  return keys;
+}
+
+/**
+ * Chinese tutorial ranking is curated `chineseTutorialArticles` ∪ Discover
+ * stories that are real Chinese X Articles (`resolvedXArticleUrl` plus
+ * zh-Hans/zh-Hant). Curated wins on article id / tweet id / slug so
+ * localized titles stay preferred. True X Articles such as Chris FAQ or
+ * JuneDangg therefore appear even when ingest only published them to Discover.
+ * `format: "article"` alone is not enough — many Discover rows are long posts,
+ * not X Articles.
+ */
 export function chineseTeachingArticleStories() {
-  return [...chineseTutorialArticles];
+  const seen = new Set<string>();
+  const stories: DiscoverStory[] = [];
+
+  const consider = (story: DiscoverStory) => {
+    const keys = teachingArticleKeys(story);
+    if (keys.some((key) => seen.has(key))) return;
+    keys.forEach((key) => seen.add(key));
+    stories.push(story);
+  };
+
+  for (const story of chineseTutorialArticles) consider(story);
+  for (const story of discoverStories) {
+    if (!isChineseTeachingXArticle(story)) continue;
+    consider(story);
+  }
+  return stories;
 }
 
 export function chineseTeachingArticlesByViews(limit?: number) {

--- a/lib/ingest/fetch-post.ts
+++ b/lib/ingest/fetch-post.ts
@@ -1,4 +1,4 @@
-import { hasXArticleLink, parseXUrl } from "./x-url";
+import { hasXArticleLink, parseXUrl, xArticleUrlFromText } from "./x-url";
 
 export type FetchedPost = {
   url: string;
@@ -11,6 +11,7 @@ export type FetchedPost = {
   sourceText: string;
   isNoteTweet?: boolean;
   isArticle?: boolean;
+  articleUrl?: string;
 };
 
 function isoDay(value: string | number) {
@@ -82,6 +83,7 @@ async function fromFxTwitter(id: string): Promise<FetchedPost | null> {
   const url = tweet.url ?? `https://x.com/${tweet.author.screen_name}/status/${id}`;
   const isNoteTweet = Boolean(tweet.is_note_tweet);
   const sourceParts = [text, quoted, articleBody].filter(Boolean);
+  const articleUrl = xArticleUrlFromText(text) ?? xArticleUrlFromText(url) ?? xArticleUrlFromText(articleBody);
   return {
     url,
     id,
@@ -92,7 +94,8 @@ async function fromFxTwitter(id: string): Promise<FetchedPost | null> {
     publishedAt,
     sourceText: sourceParts.join("\n\n"),
     isNoteTweet,
-    isArticle: isLongFormXPost({ url, text, isNoteTweet }) || Boolean(articleBody),
+    isArticle: isLongFormXPost({ url, text, isNoteTweet }) || Boolean(articleBody) || Boolean(articleUrl),
+    articleUrl,
   };
 }
 
@@ -112,6 +115,7 @@ async function fromOEmbed(url: string, id: string): Promise<FetchedPost | null> 
     const text = data.html ? stripHtml(data.html) : "";
     const handle = data.author_url?.split("/").filter(Boolean).pop();
     if (!data.author_name || !handle || text.length < 8) continue;
+    const articleUrl = xArticleUrlFromText(text) ?? xArticleUrlFromText(url);
     return {
       url,
       id,
@@ -120,6 +124,8 @@ async function fromOEmbed(url: string, id: string): Promise<FetchedPost | null> 
       text,
       publishedAt: new Date().toISOString().slice(0, 10),
       sourceText: text,
+      isArticle: isLongFormXPost({ url, text }) || Boolean(articleUrl),
+      articleUrl,
     };
   }
   return null;
@@ -148,8 +154,10 @@ async function fromSyndication(id: string): Promise<FetchedPost | null> {
   const quoted = data.quoted_tweet?.text
     ? `${data.quoted_tweet.user?.name ?? ""} @${data.quoted_tweet.user?.screen_name ?? ""}: ${data.quoted_tweet.text}`.trim()
     : undefined;
+  const url = `https://x.com/${handle}/status/${id}`;
+  const articleUrl = xArticleUrlFromText(text) ?? xArticleUrlFromText(quoted);
   return {
-    url: `https://x.com/${handle}/status/${id}`,
+    url,
     id,
     handle,
     authorName,
@@ -157,7 +165,8 @@ async function fromSyndication(id: string): Promise<FetchedPost | null> {
     quotedText: quoted,
     publishedAt,
     sourceText: quoted ? `${text}\n\n${quoted}` : text,
-    isArticle: isLongFormXPost({ url: `https://x.com/${handle}/status/${id}`, text }),
+    isArticle: isLongFormXPost({ url, text }) || Boolean(articleUrl),
+    articleUrl,
   };
 }
 

--- a/lib/ingest/validate.ts
+++ b/lib/ingest/validate.ts
@@ -1,7 +1,7 @@
 import { discoverStories, type DiscoverStory } from "@/data/discover";
 import type { FetchedPost } from "./fetch-post";
 import type { ExtractedCase } from "./schema";
-import { tweetIdFromUrl } from "./x-url";
+import { tweetIdFromUrl, xArticleUrlFromText } from "./x-url";
 
 const GROK_SIGNAL = /grok\s*bot|\bgrok\b|@grok|@bot\b/i;
 const MIN_RELEVANCE = 90;
@@ -106,12 +106,22 @@ export function notesSayElonLiked(notes?: string) {
   return Boolean(notes && /elon\s+(liked|reposted|quoted)/i.test(notes));
 }
 
+export function articleUrlFromPost(post: FetchedPost): string | undefined {
+  return (
+    post.articleUrl ??
+    xArticleUrlFromText(post.url) ??
+    xArticleUrlFromText(post.text) ??
+    xArticleUrlFromText(post.sourceText)
+  );
+}
+
 export function toDiscoverStory(
   post: FetchedPost,
   extracted: ExtractedCase,
   slug: string,
   extras: { notes?: string } = {},
 ): DiscoverStory {
+  const articleUrl = articleUrlFromPost(post);
   return {
     slug,
     title: extracted.title.trim(),
@@ -138,7 +148,8 @@ export function toDiscoverStory(
     xPostUrl: post.url,
     sourceUrl: post.url,
     sourceLabel: `${post.authorName} on X`,
-    format: extracted.format === "article" || post.isArticle ? "article" : undefined,
+    format: extracted.format === "article" || post.isArticle || articleUrl ? "article" : undefined,
+    ...(articleUrl ? { articleUrl } : {}),
     elonLiked: extracted.elonLiked || notesSayElonLiked(extras.notes) || undefined,
   };
 }

--- a/lib/ingest/x-url.ts
+++ b/lib/ingest/x-url.ts
@@ -33,6 +33,12 @@ export function xArticleIdFromText(text: string) {
   return text.match(X_ARTICLE_RE)?.[1];
 }
 
+export function xArticleUrlFromText(text?: string): string | undefined {
+  if (!text) return undefined;
+  const id = xArticleIdFromText(text);
+  return id ? `https://x.com/i/article/${id}` : undefined;
+}
+
 export function hasXArticleLink(text: string) {
   return X_ARTICLE_RE.test(text) || /(?:x\.com|twitter\.com)\/(?:i\/)?article\//i.test(text);
 }

--- a/scripts/ingest-awesome-grok-bot.ts
+++ b/scripts/ingest-awesome-grok-bot.ts
@@ -3,7 +3,7 @@ import { discoverStories, type DiscoverStory } from "../data/discover";
 import { fetchGenericSourceMetadata, type GenericSourceType } from "../lib/ingest/fetch-source-metadata";
 import { fetchXPost, type FetchedPost } from "../lib/ingest/fetch-post";
 import { makeStorySlug } from "../lib/ingest/slug";
-import { assertStorySafe } from "../lib/ingest/validate";
+import { articleUrlFromPost, assertStorySafe } from "../lib/ingest/validate";
 import { site } from "../lib/site";
 
 const FEED_PATH = "data/source-feeds/awesome-grok-bot-field-cases.json";
@@ -202,6 +202,7 @@ function buildSafeXFallback(item: SourceCase, post: FetchedPost, existingStories
   const category = fallbackCategory(combined);
   const whoShouldTry = audienceFor(category);
   const slug = makeStorySlug(post.handle, title, new Set(existingStories.map((story) => story.slug)));
+  const articleUrl = articleUrlFromPost(post);
 
   return {
     slug,
@@ -230,7 +231,8 @@ function buildSafeXFallback(item: SourceCase, post: FetchedPost, existingStories
     xPostUrl: item.url,
     sourceUrl: item.url,
     sourceLabel: `${post.authorName} on X`,
-    format: post.isArticle ? "article" : undefined,
+    format: post.isArticle || articleUrl ? "article" : undefined,
+    ...(articleUrl ? { articleUrl } : {}),
   };
 }
 

--- a/scripts/validate-article-languages.ts
+++ b/scripts/validate-article-languages.ts
@@ -1,6 +1,8 @@
 import {
   articleExternalUrl,
+  discoverStories,
   looksLikeXArticleUrl,
+  resolvedXArticleUrl,
   xArticleIdFromUrl,
   type DiscoverStory,
 } from "../data/discover";
@@ -11,6 +13,7 @@ import {
 import { storyContentLanguage, type ArticleContentLanguage } from "../lib/article-language";
 import {
   articleLibraryStories,
+  chineseTeachingArticleStories,
   chineseTeachingArticlesByViews,
   latestArticleStories,
   topArticleStoriesByViews,
@@ -18,6 +21,7 @@ import {
 import type { Locale } from "../lib/i18n/types";
 import metricsFile from "../data/discover/x-metrics.json";
 import { tweetIdFromUrl } from "../lib/ingest/x-url";
+import { toDiscoverStory } from "../lib/ingest/validate";
 import {
   metricForStory,
   rankArticleStories,
@@ -298,10 +302,90 @@ function main() {
     );
   }
 
-  const expectedTutorialOrder = rankArticleStories(chineseTutorialArticles, {
-    locale: "zh-Hans",
-    by: "views",
-  });
+  const teachingStories = chineseTeachingArticleStories();
+  check(teachingStories.length > 0, "chineseTeachingArticleStories() is empty");
+
+  for (const story of chineseTutorialArticles) {
+    check(
+      teachingStories.some((item) => item.slug === story.slug),
+      "Curated Chinese tutorial missing from ranking union: " + story.slug,
+    );
+  }
+
+  check(
+    teachingStories.some((item) => item.slug === "zh-tutorial-junedangg-topic-scout"),
+    "JuneDangg curated tutorial is missing from chineseTeachingArticleStories()",
+  );
+  check(
+    !teachingStories.some((item) => item.slug === "junedangg-9-grok-bot-ai-4-7-x"),
+    "Discover JuneDangg row must lose to the curated tutorial on article/tweet id",
+  );
+
+  for (const story of teachingStories) {
+    const curated = chineseTutorialArticles.some((item) => item.slug === story.slug);
+    check(
+      Boolean(resolvedXArticleUrl(story)),
+      "Chinese ranking row is not a real X Article: " + story.slug,
+    );
+    if (curated) continue;
+    const language = storyContentLanguage(story);
+    check(
+      language === "zh-Hans" || language === "zh-Hant",
+      "Auto-included Discover row is not Chinese: " + story.slug + " (" + language + ")",
+    );
+  }
+
+  const formatOnlyArticle = discoverStories.find(
+    (story) => story.format === "article" && !resolvedXArticleUrl(story),
+  );
+  if (formatOnlyArticle) {
+    check(
+      !teachingStories.some((item) => item.slug === formatOnlyArticle.slug),
+      "format:article without an X Article URL must not enter Chinese ranking: " +
+        formatOnlyArticle.slug,
+    );
+  }
+
+  const ingestedArticle = toDiscoverStory(
+    {
+      url: "https://x.com/JuneDangg/status/2097145937034723607",
+      id: "2097145937034723607",
+      handle: "JuneDangg",
+      authorName: "君定老師",
+      text: "手搓出第一只AI选题编辑 https://x.com/i/article/2097125111187001344",
+      publishedAt: "2026-09-08",
+      sourceText: "手搓出第一只AI选题编辑 https://x.com/i/article/2097125111187001344",
+      isArticle: true,
+    },
+    {
+      relevant: true,
+      relevance: 95,
+      reason: "Public Chinese X Article.",
+      title: "我用了9%的Grok Bot周用量，手搓出第一只AI选题编辑",
+      headline: "我用了9%的Grok Bot周用量，手搓出第一只AI选题编辑",
+      whatTheyDid: "Trained a Topic Scout editor with Grok Bot.",
+      howItWorks: "UseGrokBot ingested this public X post.",
+      whyUseful: "A public Chinese X Article.",
+      whyItMatters: "The original X Article is the source.",
+      whoShouldTry: ["Chinese-speaking Grok Bot users"],
+      usefulFor: "Chinese-speaking Grok Bot users",
+      output: "A trained Topic Scout editor.",
+      category: "content",
+      outcomes: ["create-content", "automate-work"],
+      apps: ["x"],
+      difficulty: "medium",
+      schedule: "one-time",
+      format: "article",
+    },
+    "ingest-article-url-check",
+  );
+  check(
+    ingestedArticle.articleUrl === "https://x.com/i/article/2097125111187001344",
+    "toDiscoverStory() must persist articleUrl from an i/article link, got " +
+      String(ingestedArticle.articleUrl),
+  );
+
+  const expectedTutorialOrder = rankArticleStories(teachingStories, { by: "views" });
   const actualTutorialOrder = chineseTeachingArticlesByViews();
   if (actualTutorialOrder.length > 0) {
     check(
@@ -376,7 +460,9 @@ function main() {
   console.log(
     "Validated " +
       chineseTutorialArticles.length +
-      " Chinese tutorial article URLs, view-count order, and locale-aware Top" +
+      " curated Chinese tutorial article URLs, " +
+      teachingStories.length +
+      " ranking-union rows, view-count order, and locale-aware Top" +
       TOP_LIMIT +
       "/Latest" +
       LATEST_LIMIT +


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Chinese tutorial ranking (`/zh-cn/articles/x`) is now curated `chineseTutorialArticles` ∪ Discover stories that are real Chinese X Articles (`resolvedXArticleUrl` + `zh-Hans`/`zh-Hant`). Curated entries win on article id / tweet id / slug so localized titles stay preferred.

Ingest now persists `articleUrl` when the X post is an Article or the body contains an `i/article` link.

Backfill JuneDangg Topic Scout as `zh-tutorial-junedangg-topic-scout` (first-person how-to; no invented IDs).

## Why

Discover ingest did not promote true X Articles onto the Chinese ranking, so posts could appear on Discover but miss `/zh-cn/articles/x` (JuneDangg; Chris FAQ class). `format: "article"` alone is not enough — many Discover rows are long posts, not X Articles.

## Checks

- [x] No invented X authors, handles, tweet IDs, or result numbers
- [x] Community stories link back to the original source
- [x] Tested is only used after UseGrokBot actually ran the Bot
- [x] Translations keep the same message keys
- [x] `validate:article-languages` and `validate:bookmarks` pass with the union behavior

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2faef9d9-5866-4cbb-807f-543d7149b46f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2faef9d9-5866-4cbb-807f-543d7149b46f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

